### PR TITLE
Fix duplicate scans

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -8,6 +8,7 @@ use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\LayerResolver\ChainLayerResolver;
 use Boundwize\StructArmed\LayerResolver\Resolvers\NamespaceLayerResolver;
 use Boundwize\StructArmed\Preset\Presets\Psr4Preset;
+use Boundwize\StructArmed\Rule\MultipleRuleViolationInterface;
 use Boundwize\StructArmed\Rule\ProjectRuleInterface;
 use Boundwize\StructArmed\Rule\RuleInterface;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4SourcePathsRule;
@@ -21,6 +22,8 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 
+use function array_unique;
+use function array_values;
 use function file_get_contents;
 use function fnmatch;
 use function getcwd;
@@ -133,21 +136,25 @@ final readonly class Analyser
                     continue;
                 }
 
-                $violation = $rule->evaluate($classNode);
+                $violations = $rule instanceof MultipleRuleViolationInterface
+                    ? $rule->evaluateAll($classNode)
+                    : [$rule->evaluate($classNode)];
 
-                if (! $violation instanceof RuleViolation) {
-                    continue;
+                foreach ($violations as $violation) {
+                    if (! $violation instanceof RuleViolation) {
+                        continue;
+                    }
+
+                    // Inject the rule key into the violation
+                    $ruleViolationCollection->add(new RuleViolation(
+                        ruleKey:   $key,
+                        message:   $violation->message,
+                        file:      $violation->file,
+                        line:      $violation->line,
+                        className: $violation->className,
+                        layer:     $violation->layer,
+                    ));
                 }
-
-                // Inject the rule key into the violation
-                $ruleViolationCollection->add(new RuleViolation(
-                    ruleKey:   $key,
-                    message:   $violation->message,
-                    file:      $violation->file,
-                    line:      $violation->line,
-                    className: $violation->className,
-                    layer:     $violation->layer,
-                ));
             }
         }
 
@@ -181,7 +188,7 @@ final readonly class Analyser
     private function scanPaths(array $layers, array $scanPaths): array
     {
         if ($scanPaths !== []) {
-            return $scanPaths;
+            return array_values(array_unique($scanPaths));
         }
 
         $paths = [];
@@ -192,7 +199,7 @@ final readonly class Analyser
             }
         }
 
-        return $paths;
+        return array_values(array_unique($paths));
     }
 
     /**

--- a/src/Analyser/ClassCollector.php
+++ b/src/Analyser/ClassCollector.php
@@ -187,6 +187,7 @@ final class ClassCollector extends NodeVisitorAbstract
                 paramCount:           count($classMethod->params),
                 cyclomaticComplexity: $this->calculateComplexity($classMethod),
                 lineCount:            ($classMethod->getEndLine() - $classMethod->getStartLine()) + 1,
+                line:                 $classMethod->getStartLine(),
             );
         }
 

--- a/src/Analyser/MethodNode.php
+++ b/src/Analyser/MethodNode.php
@@ -14,6 +14,7 @@ final readonly class MethodNode
         public int $paramCount,
         public int $cyclomaticComplexity,
         public int $lineCount,
+        public int $line = 0,
     ) {
     }
 

--- a/src/Rule/MultipleRuleViolationInterface.php
+++ b/src/Rule/MultipleRuleViolationInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Rule;
+
+use Boundwize\StructArmed\Analyser\ClassNode;
+
+interface MultipleRuleViolationInterface
+{
+    /**
+     * @return list<RuleViolation>
+     */
+    public function evaluateAll(ClassNode $classNode): array;
+}

--- a/src/Rule/Rules/Method/MaxCyclomaticComplexityRule.php
+++ b/src/Rule/Rules/Method/MaxCyclomaticComplexityRule.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Boundwize\StructArmed\Rule\Rules\Method;
 
 use Boundwize\StructArmed\Analyser\ClassNode;
+use Boundwize\StructArmed\Rule\MultipleRuleViolationInterface;
 use Boundwize\StructArmed\Rule\RuleInterface;
 use Boundwize\StructArmed\Rule\RuleViolation;
 
 use function sprintf;
 
-final readonly class MaxCyclomaticComplexityRule implements RuleInterface
+final readonly class MaxCyclomaticComplexityRule implements RuleInterface, MultipleRuleViolationInterface
 {
     public function __construct(
         private string $layer,
@@ -25,9 +26,19 @@ final readonly class MaxCyclomaticComplexityRule implements RuleInterface
 
     public function evaluate(ClassNode $classNode): ?RuleViolation
     {
+        return $this->evaluateAll($classNode)[0] ?? null;
+    }
+
+    /**
+     * @return list<RuleViolation>
+     */
+    public function evaluateAll(ClassNode $classNode): array
+    {
+        $violations = [];
+
         foreach ($classNode->methods as $method) {
             if ($method->cyclomaticComplexity > $this->maxComplexity) {
-                return new RuleViolation(
+                $violations[] = new RuleViolation(
                     ruleKey:   '',
                     message:   sprintf(
                         'Method [%s::%s()] has cyclomatic complexity of %d, maximum allowed is %d',
@@ -37,13 +48,13 @@ final readonly class MaxCyclomaticComplexityRule implements RuleInterface
                         $this->maxComplexity
                     ),
                     file:      $classNode->file,
-                    line:      $classNode->line,
+                    line:      $method->line !== 0 ? $method->line : $classNode->line,
                     className: $classNode->className,
                     layer:     $classNode->layer,
                 );
             }
         }
 
-        return null;
+        return $violations;
     }
 }

--- a/src/Rule/Rules/Method/MaxMethodLengthRule.php
+++ b/src/Rule/Rules/Method/MaxMethodLengthRule.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Boundwize\StructArmed\Rule\Rules\Method;
 
 use Boundwize\StructArmed\Analyser\ClassNode;
+use Boundwize\StructArmed\Rule\MultipleRuleViolationInterface;
 use Boundwize\StructArmed\Rule\RuleInterface;
 use Boundwize\StructArmed\Rule\RuleViolation;
 
 use function sprintf;
 
-final readonly class MaxMethodLengthRule implements RuleInterface
+final readonly class MaxMethodLengthRule implements RuleInterface, MultipleRuleViolationInterface
 {
     public function __construct(
         private string $layer,
@@ -25,9 +26,19 @@ final readonly class MaxMethodLengthRule implements RuleInterface
 
     public function evaluate(ClassNode $classNode): ?RuleViolation
     {
+        return $this->evaluateAll($classNode)[0] ?? null;
+    }
+
+    /**
+     * @return list<RuleViolation>
+     */
+    public function evaluateAll(ClassNode $classNode): array
+    {
+        $violations = [];
+
         foreach ($classNode->methods as $method) {
             if ($method->lineCount > $this->maxLines) {
-                return new RuleViolation(
+                $violations[] = new RuleViolation(
                     ruleKey:   '',
                     message:   sprintf(
                         'Method [%s::%s()] is %d lines long, maximum allowed is %d',
@@ -37,13 +48,13 @@ final readonly class MaxMethodLengthRule implements RuleInterface
                         $this->maxLines
                     ),
                     file:      $classNode->file,
-                    line:      $classNode->line,
+                    line:      $method->line !== 0 ? $method->line : $classNode->line,
                     className: $classNode->className,
                     layer:     $classNode->layer,
                 );
             }
         }
 
-        return null;
+        return $violations;
     }
 }

--- a/src/Rule/Rules/Method/MustHaveReturnTypeRule.php
+++ b/src/Rule/Rules/Method/MustHaveReturnTypeRule.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Boundwize\StructArmed\Rule\Rules\Method;
 
 use Boundwize\StructArmed\Analyser\ClassNode;
+use Boundwize\StructArmed\Rule\MultipleRuleViolationInterface;
 use Boundwize\StructArmed\Rule\RuleInterface;
 use Boundwize\StructArmed\Rule\RuleViolation;
 
 use function preg_match;
 use function sprintf;
 
-final readonly class MustHaveReturnTypeRule implements RuleInterface
+final readonly class MustHaveReturnTypeRule implements RuleInterface, MultipleRuleViolationInterface
 {
     public function __construct(
         private string $layer,
@@ -34,13 +35,23 @@ final readonly class MustHaveReturnTypeRule implements RuleInterface
 
     public function evaluate(ClassNode $classNode): ?RuleViolation
     {
+        return $this->evaluateAll($classNode)[0] ?? null;
+    }
+
+    /**
+     * @return list<RuleViolation>
+     */
+    public function evaluateAll(ClassNode $classNode): array
+    {
+        $violations = [];
+
         foreach ($classNode->methods as $method) {
             if (! $method->isPublic() || $method->isConstructor()) {
                 continue;
             }
 
             if (! $method->hasReturnType) {
-                return new RuleViolation(
+                $violations[] = new RuleViolation(
                     ruleKey:   '',
                     message:   sprintf(
                         'Public method [%s::%s()] must declare a return type',
@@ -48,13 +59,13 @@ final readonly class MustHaveReturnTypeRule implements RuleInterface
                         $method->name
                     ),
                     file:      $classNode->file,
-                    line:      $classNode->line,
+                    line:      $method->line !== 0 ? $method->line : $classNode->line,
                     className: $classNode->className,
                     layer:     $classNode->layer,
                 );
             }
         }
 
-        return null;
+        return $violations;
     }
 }

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -8,6 +8,7 @@ use Boundwize\StructArmed\Analyser\Analyser;
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Preset\Preset;
 use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
+use Boundwize\StructArmed\Rule\Rules\Method\MaxMethodLengthRule;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -171,6 +172,60 @@ final class AnalyserTest extends TestCase
             '/src/Foo.php',
             $this->normalisePath($ruleViolationCollection->forRule('source.must_be_final')[0]->file)
         );
+    }
+
+    public function testAnalyserDoesNotScanDuplicateLayerPathsTwice(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/Foo.php' => '<?php namespace App; class Foo {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Source', ['src/', 'src/'])
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
+
+        $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
+    }
+
+    public function testAnalyserReportsAllViolationsFromMultipleViolationRules(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/Foo.php' => <<<'PHP'
+                <?php
+
+                namespace App;
+
+                class Foo
+                {
+                    public function first(): void
+                    {
+                        $a = 1;
+                        $b = 2;
+                    }
+
+                    public function second(): void
+                    {
+                        $a = 1;
+                        $b = 2;
+                        $c = 3;
+                    }
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Source', 'src/')
+            ->rule('source.max_method_length', new MaxMethodLengthRule('Source', 2));
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
+
+        $violations = $ruleViolationCollection->forRule('source.max_method_length');
+
+        $this->assertCount(2, $violations);
+        $this->assertStringContainsString('first', $violations[0]->message);
+        $this->assertStringContainsString('second', $violations[1]->message);
     }
 
     public function testDefaultPsr4PresetDetectsClassesThatDoNotMatchScannedComposerPath(): void

--- a/tests/Rule/Method/MaxMethodLengthRuleTest.php
+++ b/tests/Rule/Method/MaxMethodLengthRuleTest.php
@@ -40,6 +40,22 @@ final class MaxMethodLengthRuleTest extends TestCase
         );
     }
 
+    private function makeNodeWithMethods(MethodNode ...$methods): ClassNode
+    {
+        return new ClassNode(
+            className:   'App\\Controller\\OrderController',
+            file:        '/fake.php',
+            line:        1,
+            layer:       'Controller',
+            extends:     null,
+            isAbstract:  false,
+            isFinal:     true,
+            isInterface: false,
+            isReadonly:  false,
+            methods:     $methods,
+        );
+    }
+
     public function testPassesWhenMethodUnderLimit(): void
     {
         $maxMethodLengthRule = new MaxMethodLengthRule(layer: 'Controller', maxLines: 20);
@@ -66,6 +82,24 @@ final class MaxMethodLengthRuleTest extends TestCase
         $this->assertInstanceOf(RuleViolation::class, $violation);
         $this->assertStringContainsString('35', $violation->message);
         $this->assertStringContainsString('20', $violation->message);
+    }
+
+    public function testReportsAllMethodsOverLimit(): void
+    {
+        $maxMethodLengthRule = new MaxMethodLengthRule(layer: 'Controller', maxLines: 20);
+        $classNode           = $this->makeNodeWithMethods(
+            new MethodNode('store', 'public', true, false, 1, 2, 35, 11),
+            new MethodNode('update', 'public', true, false, 1, 2, 28, 47),
+            new MethodNode('show', 'public', true, false, 1, 2, 12, 83),
+        );
+
+        $violations = $maxMethodLengthRule->evaluateAll($classNode);
+
+        $this->assertCount(2, $violations);
+        $this->assertStringContainsString('store', $violations[0]->message);
+        $this->assertSame(11, $violations[0]->line);
+        $this->assertStringContainsString('update', $violations[1]->message);
+        $this->assertSame(47, $violations[1]->line);
     }
 
     public function testDoesNotApplyToWrongLayer(): void


### PR DESCRIPTION
I tested in a project ci4-album, and sometime, it doesn't show all violations

---- Normal use of Preset::DDD() ----
➜  ci4-album git:(start-using-struct-armed) ✗ vendor/bin/structarmed analyze

```
StructArmed — Architecture Enforcement
==========================================

Found 4 violation(s):
──────────────────────────────────────────

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Track::add()] is 34 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Track.php:25
   Layer: Application

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Album::edit()] is 24 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Album.php:23
   Layer: Application

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Track::add()] is 34 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Track.php:25
   Layer: Application

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Album::edit()] is 24 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Album.php:23
   Layer: Application

──────────────────────────────────────────
4 violation(s) found  •  0.12s
```

then, I update to:

---- Normal use of Preset::DDD(maxMethodLength: 34) ----


➜  ci4-album git:(start-using-struct-armed) ✗ vendor/bin/structarmed analyze

```
StructArmed — Architecture Enforcement
==========================================

Found 2 violation(s):
──────────────────────────────────────────

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Track::edit()] is 36 lines long, maximum allowed is 34
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Track.php:25
   Layer: Application

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Track::edit()] is 36 lines long, maximum allowed is 34
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Track.php:25
   Layer: Application
 ```
 
 This patch fix it, now all collected:
 
 ```
 ➜  ci4-album git:(start-using-struct-armed) ✗ vendor/bin/structarmed analyze

StructArmed — Architecture Enforcement
==========================================

Found 6 violation(s):
──────────────────────────────────────────

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Track::add()] is 34 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Track.php:86
   Layer: Application

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Track::edit()] is 36 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Track.php:121
   Layer: Application

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Album::edit()] is 24 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Album.php:88
   Layer: Application

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Track::add()] is 34 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Track.php:86
   Layer: Application

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Track::edit()] is 36 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Track.php:121
   Layer: Application

✗  [ddd.safety.application_max_method_length]
   Method [Album\Controllers\Album::edit()] is 24 lines long, maximum allowed is 20
   → /Users/samsonasik/www/GithubModules/ci4-album/src/Controllers/Album.php:88
   Layer: Application

──────────────────────────────────────────
6 violation(s) found  •  0.12s
```