### PR TITLE
Allow define multiple layers in same directory

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -252,7 +252,7 @@ final readonly class Analyser
             }
         }
 
-        return $files;
+        return array_values(array_unique($files));
     }
 
     /**

--- a/src/LayerResolver/Resolvers/NamespaceLayerResolver.php
+++ b/src/LayerResolver/Resolvers/NamespaceLayerResolver.php
@@ -48,7 +48,7 @@ final readonly class NamespaceLayerResolver implements LayerResolverInterface
                 if (str_starts_with($normalised, $normalisedLayer)) {
                     $length = strlen($normalisedLayer);
 
-                    if ($length > $matchedLength) {
+                    if ($length >= $matchedLength) {
                         $matchedLayer  = $layerName;
                         $matchedLength = $length;
                     }

--- a/tests/LayerResolver/NamespaceLayerResolverTest.php
+++ b/tests/LayerResolver/NamespaceLayerResolverTest.php
@@ -95,6 +95,24 @@ final class NamespaceLayerResolverTest extends TestCase
         $this->assertSame('Infrastructure', $layer);
     }
 
+    public function testLastDefinedLayerWinsWhenPathsAreIdentical(): void
+    {
+        $namespaceLayerResolver = new NamespaceLayerResolver(
+            layers: [
+                'Application' => 'src/Controllers/',
+                'Controller'  => 'src/Controllers/',
+            ],
+            basePath: $this->basePath
+        );
+
+        $layer = $namespaceLayerResolver->resolve(
+            'App\\Controllers\\AlbumController',
+            $this->basePath . '/src/Controllers/AlbumController.php'
+        );
+
+        $this->assertSame('Controller', $layer);
+    }
+
     public function testPatternResolverMatchesClassName(): void
     {
         $patternLayerResolver = new PatternLayerResolver([


### PR DESCRIPTION
To allow this kind of config:

```php
<?php

declare(strict_types=1);

use Boundwize\StructArmed\Architecture;
use Boundwize\StructArmed\Preset\Preset;
use Boundwize\StructArmed\Preset\Presets\Psr4Preset;

return Architecture::define()
    ->skip([
        Psr4Preset::CLASSES_MUST_MATCH_COMPOSER => [
            __DIR__ . '/src/Database/Migrations',
        ],
    ])

    // a directory can have multiple layers
     // this is for DDD preset
    ->layer('Application', 'src/Controllers/')
    // this is for MVC preset
    ->layer('Controller', 'src/Controllers/')

    ->withPresets(Preset::PSR4(), Preset::DDD(maxMethodLength: 36), Preset::MVC());

```