### PR TITLE
Allow set null cacheDirectory

### DIFF
--- a/src/Architecture.php
+++ b/src/Architecture.php
@@ -140,7 +140,7 @@ final class Architecture
         return $this;
     }
 
-    public function cacheDirectory(string $cacheDirectory): self
+    public function cacheDirectory(?string $cacheDirectory): self
     {
         $this->cacheDirectory = $cacheDirectory;
 

--- a/tests/ArchitectureTest.php
+++ b/tests/ArchitectureTest.php
@@ -103,6 +103,14 @@ final class ArchitectureTest extends TestCase
         $this->assertSame('var/cache/structarmed', $architecture->getCacheDirectory());
     }
 
+    public function testCacheDirectoryCanBeNull(): void
+    {
+        $architecture = Architecture::define()
+            ->cacheDirectory(null);
+
+        $this->assertNull($architecture->getCacheDirectory());
+    }
+
     public function testRuleIsAdded(): void
     {
         $mustBeFinalRule = new MustBeFinalRule(layer: 'Domain');


### PR DESCRIPTION
If pass null, StructArmed falls back to its default cache directory behavior. Useful for on CI usage

```
    ->cacheDirectory(
        // Github action cache or local
        is_dir('/tmp') ? '/tmp/rector' : null
    )
```