### PR TITLE
Fix edge case in NamespaceLayerResolver on same prefix directory

### DIFF
--- a/src/LayerResolver/Resolvers/NamespaceLayerResolver.php
+++ b/src/LayerResolver/Resolvers/NamespaceLayerResolver.php
@@ -55,7 +55,7 @@ final readonly class NamespaceLayerResolver implements LayerResolverInterface
 
         foreach ($this->normalisedLayers as $layerName => $layerPaths) {
             foreach ($layerPaths as $layerPath) {
-                if (str_starts_with($normalised, $layerPath)) {
+                if ($this->matchesLayerPath($normalised, $layerPath)) {
                     $length = strlen($layerPath);
 
                     if ($length > $matchedLength) {
@@ -79,7 +79,7 @@ final readonly class NamespaceLayerResolver implements LayerResolverInterface
 
         foreach ($this->normalisedLayers as $layerName => $layerPaths) {
             foreach ($layerPaths as $layerPath) {
-                if (str_starts_with($normalised, $layerPath)) {
+                if ($this->matchesLayerPath($normalised, $layerPath)) {
                     $matched[] = $layerName;
                     break;
                 }
@@ -92,5 +92,10 @@ final readonly class NamespaceLayerResolver implements LayerResolverInterface
     private function normalisePath(string $path): string
     {
         return rtrim(str_replace('\\', '/', realpath($path) ?: $path), '/');
+    }
+
+    private function matchesLayerPath(string $path, string $layerPath): bool
+    {
+        return $path === $layerPath || str_starts_with($path, $layerPath . '/');
     }
 }

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -112,6 +112,47 @@ final class AnalyserTest extends TestCase
         $this->assertCount(2, $ruleViolationCollection->forRule('source.must_be_final'));
     }
 
+    public function testArchitectureLayerPathDoesNotMatchSiblingDirectoryWithSamePrefix(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/App/Controller.php'      => '<?php namespace Project\App; class Controller {}',
+            'src/Application/UseCase.php' => '<?php namespace Project\Application; class UseCase {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('App', 'src/App/')
+            ->layer('Application', 'src/Application/')
+            ->rule('app.must_be_final', new MustBeFinalRule('App'));
+
+        $ruleViolationCollection = (new Analyser($basePath))
+            ->analyse($architecture, [], null, AnalyserOptions::sequential());
+
+        $violations = $ruleViolationCollection->forRule('app.must_be_final');
+
+        $this->assertCount(1, $violations);
+        $this->assertStringEndsWith('/src/App/Controller.php', $this->normalisePath($violations[0]->file));
+    }
+
+    public function testArchitectureLayerCanBeConfiguredForSingleFilePath(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/Foo.php' => '<?php namespace App; class Foo {}',
+            'src/Bar.php' => '<?php namespace App; class Bar {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Source', 'src/Foo.php')
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        $ruleViolationCollection = (new Analyser($basePath))
+            ->analyse($architecture, [], null, AnalyserOptions::sequential());
+
+        $violations = $ruleViolationCollection->forRule('source.must_be_final');
+
+        $this->assertCount(1, $violations);
+        $this->assertStringEndsWith('/src/Foo.php', $this->normalisePath($violations[0]->file));
+    }
+
     public function testAnalyserReturnsEmptyCollectionForEmptyLayers(): void
     {
         $architecture = Architecture::define()

--- a/tests/LayerResolver/NamespaceLayerResolverTest.php
+++ b/tests/LayerResolver/NamespaceLayerResolverTest.php
@@ -94,6 +94,21 @@ final class NamespaceLayerResolverTest extends TestCase
         $this->assertSame('Infrastructure', $layer);
     }
 
+    public function testDoesNotResolveSiblingPathWithSamePrefix(): void
+    {
+        $namespaceLayerResolver = new NamespaceLayerResolver(
+            layers: ['App' => 'src/App/'],
+            basePath: $this->basePath
+        );
+
+        $layer = $namespaceLayerResolver->resolve(
+            'Project\\Application\\Service',
+            $this->basePath . '/src/Application/Service.php'
+        );
+
+        $this->assertNull($layer);
+    }
+
     public function testResolveAllReturnsAllMatchingLayers(): void
     {
         $namespaceLayerResolver = new NamespaceLayerResolver(
@@ -111,6 +126,21 @@ final class NamespaceLayerResolverTest extends TestCase
 
         $this->assertContains('Application', $layers);
         $this->assertContains('Controller', $layers);
+    }
+
+    public function testResolveAllDoesNotReturnSiblingPathWithSamePrefix(): void
+    {
+        $namespaceLayerResolver = new NamespaceLayerResolver(
+            layers: ['App' => 'src/App/'],
+            basePath: $this->basePath
+        );
+
+        $layers = $namespaceLayerResolver->resolveAll(
+            'Project\\Application\\Service',
+            $this->basePath . '/src/Application/Service.php'
+        );
+
+        $this->assertSame([], $layers);
     }
 
     public function testResolveAllReturnsEmptyForUnknownPath(): void


### PR DESCRIPTION
```php
Architecture::define()
    ->layer('App', 'src/App/')
    ->layer('Application', 'src/Application/');
```

Previously, `src/Application/UseCase.php` could be resolved as part of the App layer because the resolver used a raw prefix check. The resolver now only matches:

- the exact configured path, such as src/Foo.php
- a child path inside the configured directory, such as src/App/Controller.php