### PR TITLE
Revert " Fix early break on deep layers on NamespaceLayerResolver::resolveAll() "

### DIFF
--- a/src/LayerResolver/Resolvers/NamespaceLayerResolver.php
+++ b/src/LayerResolver/Resolvers/NamespaceLayerResolver.php
@@ -52,18 +52,44 @@ final readonly class NamespaceLayerResolver implements LayerResolverInterface
 
     public function resolve(string $className, string $filePath): ?string
     {
+        return $this->resolveMatches($filePath)['matchedLayer'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resolveAll(string $className, string $filePath): array
+    {
+        return $this->resolveMatches($filePath)['matchedLayers'];
+    }
+
+    /**
+     * @return array{matchedLayer: string|null, matchedLayers: list<string>}
+     */
+    private function resolveMatches(string $filePath): array
+    {
         $normalised = $this->normalisePath($filePath);
 
-        if ($this->namespaceLayerResolverCache->hasMatchedLayer($normalised)) {
-            return $this->namespaceLayerResolverCache->getMatchedLayer($normalised);
+        $matches = $this->namespaceLayerResolverCache->get($normalised);
+
+        if ($matches !== null) {
+            return $matches;
         }
 
         $matchedLayer  = null;
+        $matchedLayers = [];
         $matchedLength = -1;
 
         foreach ($this->normalisedLayers as $layerName => $layerPaths) {
+            $layerMatched = false;
+
             foreach ($layerPaths as $layerPath) {
                 if ($this->matchesLayerPath($normalised, $layerPath)) {
+                    if (! $layerMatched) {
+                        $matchedLayers[] = $layerName;
+                        $layerMatched    = true;
+                    }
+
                     $length = strlen($layerPath);
 
                     if ($length > $matchedLength) {
@@ -74,36 +100,14 @@ final readonly class NamespaceLayerResolver implements LayerResolverInterface
             }
         }
 
-        $this->namespaceLayerResolverCache->setMatchedLayer($normalised, $matchedLayer);
+        $matches = [
+            'matchedLayer'  => $matchedLayer,
+            'matchedLayers' => $matchedLayers,
+        ];
 
-        return $matchedLayer;
-    }
+        $this->namespaceLayerResolverCache->set($normalised, $matches);
 
-    /**
-     * @return list<string>
-     */
-    public function resolveAll(string $className, string $filePath): array
-    {
-        $normalised = $this->normalisePath($filePath);
-
-        if ($this->namespaceLayerResolverCache->hasMatchedLayers($normalised)) {
-            return $this->namespaceLayerResolverCache->getMatchedLayers($normalised);
-        }
-
-        $matchedLayers = [];
-
-        foreach ($this->normalisedLayers as $layerName => $layerPaths) {
-            foreach ($layerPaths as $layerPath) {
-                if ($this->matchesLayerPath($normalised, $layerPath)) {
-                    $matchedLayers[] = $layerName;
-                    continue 2;
-                }
-            }
-        }
-
-        $this->namespaceLayerResolverCache->setMatchedLayers($normalised, $matchedLayers);
-
-        return $matchedLayers;
+        return $matches;
     }
 
     private function normalisePath(string $path): string

--- a/src/LayerResolver/Resolvers/NamespaceLayerResolverCache.php
+++ b/src/LayerResolver/Resolvers/NamespaceLayerResolverCache.php
@@ -4,52 +4,27 @@ declare(strict_types=1);
 
 namespace Boundwize\StructArmed\LayerResolver\Resolvers;
 
-use function array_key_exists;
-
 /**
  * @internal
  */
 final class NamespaceLayerResolverCache
 {
-    /** @var array<string, string|null> */
-    private array $matchedLayerByPath = [];
+    /** @var array<string, array{matchedLayer: string|null, matchedLayers: list<string>}> */
+    private array $matchesByPath = [];
 
-    /** @var array<string, list<string>> */
-    private array $matchedLayersByPath = [];
-
-    public function hasMatchedLayer(string $path): bool
+    /**
+     * @return array{matchedLayer: string|null, matchedLayers: list<string>}|null
+     */
+    public function get(string $path): ?array
     {
-        return array_key_exists($path, $this->matchedLayerByPath);
-    }
-
-    public function getMatchedLayer(string $path): ?string
-    {
-        return $this->matchedLayerByPath[$path] ?? null;
-    }
-
-    public function setMatchedLayer(string $path, ?string $matchedLayer): void
-    {
-        $this->matchedLayerByPath[$path] = $matchedLayer;
-    }
-
-    public function hasMatchedLayers(string $path): bool
-    {
-        return array_key_exists($path, $this->matchedLayersByPath);
+        return $this->matchesByPath[$path] ?? null;
     }
 
     /**
-     * @return list<string>
+     * @param array{matchedLayer: string|null, matchedLayers: list<string>} $matches
      */
-    public function getMatchedLayers(string $path): array
+    public function set(string $path, array $matches): void
     {
-        return $this->matchedLayersByPath[$path] ?? [];
-    }
-
-    /**
-     * @param list<string> $matchedLayers
-     */
-    public function setMatchedLayers(string $path, array $matchedLayers): void
-    {
-        $this->matchedLayersByPath[$path] = $matchedLayers;
+        $this->matchesByPath[$path] = $matches;
     }
 }

--- a/tests/LayerResolver/NamespaceLayerResolverTest.php
+++ b/tests/LayerResolver/NamespaceLayerResolverTest.php
@@ -172,9 +172,6 @@ final class NamespaceLayerResolverTest extends TestCase
         $filePath               = $this->basePath . '/src/Domain/Order.php';
 
         $this->assertSame('Domain', $namespaceLayerResolver->resolve('App\\Domain\\Order', $filePath));
-        $this->assertSame('Domain', $namespaceLayerResolver->resolve('App\\Domain\\Order', $filePath));
-
-        $this->assertSame(['Source', 'Domain'], $namespaceLayerResolver->resolveAll('App\\Domain\\Order', $filePath));
         $this->assertSame(['Source', 'Domain'], $namespaceLayerResolver->resolveAll('App\\Domain\\Order', $filePath));
     }
 


### PR DESCRIPTION
Reverts boundwize/structarmed#81

Revert for now, it somehow not "hit" the part cached after it, or I just missing something :)