### PR TITLE
Avoid JSON_PRETTY_PRINT unless for json reporting

### DIFF
--- a/src/Cache/AnalysisResultCache.php
+++ b/src/Cache/AnalysisResultCache.php
@@ -39,7 +39,6 @@ use function sys_get_temp_dir;
 use function unlink;
 
 use const JSON_INVALID_UTF8_SUBSTITUTE;
-use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
 
 final readonly class AnalysisResultCache
@@ -103,7 +102,7 @@ final readonly class AnalysisResultCache
         file_put_contents($this->path($key), json_encode([
             'metadata'   => $metadata,
             'violations' => $ruleViolationCollection->toArray(),
-        ], JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR));
+        ], JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR));
     }
 
     public function clear(): void
@@ -249,7 +248,7 @@ final readonly class AnalysisResultCache
         file_put_contents($this->path($this->classNodesKey($file, $namespace)), json_encode([
             'metadata' => $this->fileMetadata($file, $namespace),
             'nodes'    => array_map($this->classNodeToArray(...), $classNodes),
-        ], JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR));
+        ], JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR));
     }
 
     /**

--- a/src/Rule/RuleViolationCollection.php
+++ b/src/Rule/RuleViolationCollection.php
@@ -16,7 +16,6 @@ use function count;
 use function json_encode;
 
 use const JSON_INVALID_UTF8_SUBSTITUTE;
-use const JSON_PRETTY_PRINT;
 
 /**
  * @implements IteratorAggregate<int, RuleViolation>
@@ -91,6 +90,6 @@ final class RuleViolationCollection implements Countable, IteratorAggregate
 
     public function toJson(): string
     {
-        return (string) json_encode($this->toArray(), JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE);
+        return (string) json_encode($this->toArray(), JSON_INVALID_UTF8_SUBSTITUTE);
     }
 }

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -73,6 +73,13 @@ final class AnalysisResultCacheTest extends TestCase
             $analysisResultCache->store('key', $metadata, $ruleViolationCollection);
             $loaded = $analysisResultCache->load('key', $metadata);
 
+            $this->assertSame(
+                json_encode([
+                    'metadata'   => $metadata,
+                    'violations' => $ruleViolationCollection->toArray(),
+                ], JSON_THROW_ON_ERROR),
+                file_get_contents($cacheDirectory . '/key.json')
+            );
             $this->assertInstanceOf(RuleViolationCollection::class, $loaded);
             $this->assertSame($ruleViolationCollection->toArray(), $loaded->toArray());
         } finally {
@@ -513,6 +520,10 @@ final class AnalysisResultCacheTest extends TestCase
 
             $loaded = $analysisResultCache->loadClassNodes($sourceFile, 'config');
 
+            $this->assertStringNotContainsString(
+                "\n",
+                (string) file_get_contents($this->firstJsonFile($cacheDirectory))
+            );
             $this->assertEquals($classNodes, $loaded);
         } finally {
             if (file_exists($sourceFile)) {

--- a/tests/Rule/RuleViolationTest.php
+++ b/tests/Rule/RuleViolationTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 use function iterator_to_array;
 use function json_decode;
+use function json_encode;
 
 #[CoversClass(RuleViolation::class)]
 #[CoversClass(RuleViolationCollection::class)]
@@ -63,6 +64,7 @@ final class RuleViolationTest extends TestCase
         $this->assertCount(2, $collection);
         $this->assertSame([$ruleViolation], $collection->forLayer('Domain'));
         $this->assertSame([$app], $collection->forRule('app.rule'));
+        $this->assertSame(json_encode($collection->toArray()), $collection->toJson());
         $this->assertSame($collection->toArray(), json_decode($collection->toJson(), true));
         $this->assertSame([$ruleViolation, $app], iterator_to_array($collection));
     }


### PR DESCRIPTION
For data write/read, less bytes is better 👍 