### PR TITLE
Flag missing Composer PSR-4 directories as violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ composer require --dev boundwize/structarmed
 # defaults to --preset=psr4
 vendor/bin/structarmed init
 
-# verify source paths match composer.json PSR-4 mappings
+# verify source paths and directories match composer.json PSR-4 mappings
 vendor/bin/structarmed init --preset=psr4
 
 # enforce basic coding standard (tags, StudlyCaps, camelCase)
@@ -311,7 +311,7 @@ return Architecture::define()
 | `Preset::PSR1()` | Basic Coding Standard checks: PHP tags, UTF-8 without BOM, symbols vs side effects, PSR-4 class placement, StudlyCaps class names, upper-case class constants, camelCase methods |
 | `Preset::PSR12()` | Extends PSR-1: all methods, constants, and properties must declare explicit visibility |
 | `Preset::PSR15()` | `*Middleware` classes must implement PSR-15 `MiddlewareInterface`; `*Handler` classes must implement PSR-15 `RequestHandlerInterface`; StructArmed also enforces matching `Middleware`/`Handler` suffixes for implementations of those interfaces |
-| `Preset::PSR4()` | Verifies configured source paths exist in composer.json `autoload` or `autoload-dev` PSR-4 mappings |
+| `Preset::PSR4()` | Verifies configured source paths exist in composer.json `autoload` or `autoload-dev` PSR-4 mappings, and mapped directories exist |
 | `Preset::DDD()` | Layer isolation, entity/VO/repository/event/service conventions |
 | `Preset::MVC()` | Layer isolation, thin controllers, model/view/service rules |
 

--- a/src/Cache/AnalysisCacheMetadataFactory.php
+++ b/src/Cache/AnalysisCacheMetadataFactory.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace Boundwize\StructArmed\Cache;
 
+use Boundwize\StructArmed\Composer\Psr4PathResolver;
 use Boundwize\StructArmed\Version;
 use Composer\InstalledVersions;
 
 use function array_map;
+use function file_exists;
 use function hash;
 use function hash_file;
+use function is_dir;
 use function json_encode;
+use function ltrim;
+use function rtrim;
 use function sort;
 
 use const JSON_INVALID_UTF8_SUBSTITUTE;
@@ -18,6 +23,13 @@ use const JSON_THROW_ON_ERROR;
 
 final readonly class AnalysisCacheMetadataFactory
 {
+    private const METADATA_VERSION = 2;
+
+    public function __construct(
+        private Psr4PathResolver $psr4PathResolver = new Psr4PathResolver(),
+    ) {
+    }
+
     /**
      * @param list<string> $scanPaths
      * @param list<string> $files
@@ -28,10 +40,12 @@ final readonly class AnalysisCacheMetadataFactory
         sort($files);
 
         return [
-            'version'                      => 1,
+            'version'                      => self::METADATA_VERSION,
             'basePath'                     => $basePath,
             'configPath'                   => $configPath,
             'configHash'                   => $this->fileHash($configPath),
+            'composerJsonHash'             => $this->optionalFileHash(rtrim($basePath, '/') . '/composer.json'),
+            'composerPsr4DirectoriesHash'  => $this->composerPsr4DirectoriesHash($basePath),
             'composerGeneratedVersionHash' => $this->composerGeneratedVersionHash(),
             'scanPaths'                    => $scanPaths,
             'filesHash'                    => $this->filesHash($files),
@@ -47,6 +61,8 @@ final readonly class AnalysisCacheMetadataFactory
             'version'                      => $metadata['version'] ?? null,
             'basePath'                     => $metadata['basePath'] ?? null,
             'configPath'                   => $metadata['configPath'] ?? null,
+            'composerJsonHash'             => $metadata['composerJsonHash'] ?? null,
+            'composerPsr4DirectoriesHash'  => $metadata['composerPsr4DirectoriesHash'] ?? null,
             'composerGeneratedVersionHash' => $metadata['composerGeneratedVersionHash'] ?? null,
             'scanPaths'                    => $metadata['scanPaths'] ?? [],
         ], JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR));
@@ -55,6 +71,30 @@ final readonly class AnalysisCacheMetadataFactory
     public function fileHash(string $path): string
     {
         return (string) hash_file('xxh128', $path);
+    }
+
+    private function optionalFileHash(string $path): ?string
+    {
+        return file_exists($path) ? $this->fileHash($path) : null;
+    }
+
+    private function composerPsr4DirectoriesHash(string $basePath): string
+    {
+        $directories = [];
+
+        foreach ($this->psr4PathResolver->namespacePaths($basePath) as $namespace => $paths) {
+            foreach ($paths as $path) {
+                $directories[] = [
+                    'namespace'   => $namespace,
+                    'path'        => $path,
+                    'isDirectory' => is_dir(rtrim($basePath, '/') . '/' . ltrim($path, '/')),
+                ];
+            }
+        }
+
+        sort($directories);
+
+        return hash('xxh128', json_encode($directories, JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR));
     }
 
     /**

--- a/src/Rule/Rules/Composer/Psr4SourcePathsRule.php
+++ b/src/Rule/Rules/Composer/Psr4SourcePathsRule.php
@@ -51,6 +51,7 @@ final readonly class Psr4SourcePathsRule implements MultipleProjectRuleViolation
 
     /**
      * @return list<RuleViolation>
+     * @param string[] $skipPaths
      */
     public function evaluateProjectAll(string $basePath, Architecture $architecture, array $skipPaths = []): array
     {

--- a/src/Rule/Rules/Composer/Psr4SourcePathsRule.php
+++ b/src/Rule/Rules/Composer/Psr4SourcePathsRule.php
@@ -6,14 +6,13 @@ namespace Boundwize\StructArmed\Rule\Rules\Composer;
 
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Composer\Psr4PathResolver;
-use Boundwize\StructArmed\Rule\ProjectRuleInterface;
+use Boundwize\StructArmed\Rule\MultipleProjectRuleViolationInterface;
 use Boundwize\StructArmed\Rule\RuleViolation;
 
 use function array_map;
 use function array_unique;
 use function array_values;
 use function file_exists;
-use function implode;
 use function in_array;
 use function is_dir;
 use function ltrim;
@@ -22,7 +21,7 @@ use function sprintf;
 use function str_replace;
 use function trim;
 
-final readonly class Psr4SourcePathsRule implements ProjectRuleInterface
+final readonly class Psr4SourcePathsRule implements MultipleProjectRuleViolationInterface
 {
     /**
      * @param list<string> $sourcePaths
@@ -47,26 +46,38 @@ final readonly class Psr4SourcePathsRule implements ProjectRuleInterface
 
     public function evaluateProject(string $basePath, Architecture $architecture, array $skipPaths = []): ?RuleViolation
     {
+        return $this->evaluateProjectAll($basePath, $architecture, $skipPaths)[0] ?? null;
+    }
+
+    /**
+     * @return list<RuleViolation>
+     */
+    public function evaluateProjectAll(string $basePath, Architecture $architecture, array $skipPaths = []): array
+    {
         $composerFile = rtrim($basePath, '/') . '/composer.json';
 
         if (! file_exists($composerFile)) {
-            return $this->violation(
-                'composer.json was not found',
-                $composerFile
-            );
+            return [
+                $this->violation(
+                    'composer.json was not found',
+                    $composerFile
+                ),
+            ];
         }
 
         $composer = $this->psr4PathResolver->composerConfig($basePath);
 
         if ($composer === null) {
-            return $this->violation(
-                'composer.json is not valid JSON',
-                $composerFile
-            );
+            return [
+                $this->violation(
+                    'composer.json is not valid JSON',
+                    $composerFile
+                ),
+            ];
         }
 
         $autoloadPaths = $this->psr4PathResolver->paths($basePath);
-        $messages      = [];
+        $violations    = [];
 
         if ($this->sourcePaths !== null) {
             $missingPaths = [];
@@ -77,31 +88,28 @@ final readonly class Psr4SourcePathsRule implements ProjectRuleInterface
                 }
             }
 
-            if ($missingPaths !== []) {
-                $messages[] = sprintf(
-                    'PSR-4 source path(s) [%s] must exist in composer.json autoload or autoload-dev',
-                    implode(', ', $missingPaths)
+            foreach (array_values(array_unique($missingPaths)) as $missingPath) {
+                $violations[] = $this->violation(
+                    sprintf(
+                        'PSR-4 source path [%s] must exist in composer.json autoload or autoload-dev',
+                        $missingPath
+                    ),
+                    $composerFile
                 );
             }
         }
 
-        $missingDirectories = $this->missingComposerDirectories($basePath);
-
-        if ($missingDirectories !== []) {
-            $messages[] = sprintf(
-                'PSR-4 directory path(s) [%s] configured in composer.json autoload or autoload-dev must exist',
-                implode(', ', $missingDirectories)
+        foreach ($this->missingComposerDirectories($basePath) as $missingDirectory) {
+            $violations[] = $this->violation(
+                sprintf(
+                    'PSR-4 directory path [%s] configured in composer.json autoload or autoload-dev must exist',
+                    $missingDirectory
+                ),
+                $composerFile
             );
         }
 
-        if ($messages === []) {
-            return null;
-        }
-
-        return $this->violation(
-            implode('; ', $messages),
-            $composerFile
-        );
+        return $violations;
     }
 
     /**

--- a/src/Rule/Rules/Composer/Psr4SourcePathsRule.php
+++ b/src/Rule/Rules/Composer/Psr4SourcePathsRule.php
@@ -10,9 +10,13 @@ use Boundwize\StructArmed\Rule\ProjectRuleInterface;
 use Boundwize\StructArmed\Rule\RuleViolation;
 
 use function array_map;
+use function array_unique;
+use function array_values;
 use function file_exists;
 use function implode;
 use function in_array;
+use function is_dir;
+use function ltrim;
 use function rtrim;
 use function sprintf;
 use function str_replace;
@@ -61,28 +65,41 @@ final readonly class Psr4SourcePathsRule implements ProjectRuleInterface
             );
         }
 
-        if ($this->sourcePaths === null) {
-            return null;
-        }
-
         $autoloadPaths = $this->psr4PathResolver->paths($basePath);
-        $missingPaths  = [];
+        $messages      = [];
 
-        foreach ($this->normalisePaths($this->sourcePaths) as $sourcePath) {
-            if (! in_array($sourcePath, $autoloadPaths, true)) {
-                $missingPaths[] = $sourcePath;
+        if ($this->sourcePaths !== null) {
+            $missingPaths = [];
+
+            foreach ($this->normalisePaths($this->sourcePaths) as $sourcePath) {
+                if (! in_array($sourcePath, $autoloadPaths, true)) {
+                    $missingPaths[] = $sourcePath;
+                }
+            }
+
+            if ($missingPaths !== []) {
+                $messages[] = sprintf(
+                    'PSR-4 source path(s) [%s] must exist in composer.json autoload or autoload-dev',
+                    implode(', ', $missingPaths)
+                );
             }
         }
 
-        if ($missingPaths === []) {
+        $missingDirectories = $this->missingComposerDirectories($basePath);
+
+        if ($missingDirectories !== []) {
+            $messages[] = sprintf(
+                'PSR-4 directory path(s) [%s] configured in composer.json autoload or autoload-dev must exist',
+                implode(', ', $missingDirectories)
+            );
+        }
+
+        if ($messages === []) {
             return null;
         }
 
         return $this->violation(
-            sprintf(
-                'PSR-4 source path(s) [%s] must exist in composer.json autoload or autoload-dev',
-                implode(', ', $missingPaths)
-            ),
+            implode('; ', $messages),
             $composerFile
         );
     }
@@ -97,6 +114,26 @@ final readonly class Psr4SourcePathsRule implements ProjectRuleInterface
             static fn(string $path): string => rtrim(str_replace('\\', '/', trim($path)), '/'),
             $paths
         );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function missingComposerDirectories(string $basePath): array
+    {
+        $missingDirectories = [];
+
+        foreach ($this->psr4PathResolver->namespacePaths($basePath) as $namespace => $paths) {
+            foreach ($paths as $path) {
+                if (is_dir(rtrim($basePath, '/') . '/' . ltrim($path, '/'))) {
+                    continue;
+                }
+
+                $missingDirectories[] = $namespace === '' ? $path : $namespace . ' => ' . $path;
+            }
+        }
+
+        return array_values(array_unique($missingDirectories));
     }
 
     private function violation(string $message, string $file): RuleViolation

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -1465,6 +1465,8 @@ final class AnalysisResultCacheTest extends TestCase
             $this->assertSame($config, $metadata['configPath']);
             $this->assertSame(['src'], $metadata['scanPaths']);
             $this->assertIsString($metadata['configHash']);
+            $this->assertNull($metadata['composerJsonHash']);
+            $this->assertIsString($metadata['composerPsr4DirectoriesHash']);
             $this->assertIsString($metadata['composerGeneratedVersionHash']);
             $this->assertIsString($metadata['filesHash']);
             $this->assertSame(
@@ -1498,6 +1500,109 @@ final class AnalysisResultCacheTest extends TestCase
             '/^[a-f0-9]{32}$/',
             (new AnalysisCacheMetadataFactory())->key($metadata)
         );
+    }
+
+    public function testMetadataChangesWhenComposerJsonChanges(): void
+    {
+        $directory = $this->createTempDirectory();
+        $config    = $directory . '/structarmed.php';
+        $source    = $directory . '/Example.php';
+        $composer  = $directory . '/composer.json';
+
+        file_put_contents($config, '<?php return null;');
+        file_put_contents($source, '<?php class Example {}');
+        file_put_contents($composer, '{"autoload":{"psr-4":{"App\\\\":"src/"}}}');
+
+        try {
+            $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory();
+            $metadataBefore               = $analysisCacheMetadataFactory->metadata(
+                $directory,
+                $config,
+                ['src'],
+                [$source]
+            );
+
+            file_put_contents($composer, '{"autoload":{"psr-4":{"App\\\\":"app/"}}}');
+
+            $metadataAfter = $analysisCacheMetadataFactory->metadata(
+                $directory,
+                $config,
+                ['src'],
+                [$source]
+            );
+
+            $this->assertNotSame($metadataBefore['composerJsonHash'], $metadataAfter['composerJsonHash']);
+            $this->assertNotSame(
+                $analysisCacheMetadataFactory->key($metadataBefore),
+                $analysisCacheMetadataFactory->key($metadataAfter)
+            );
+        } finally {
+            foreach ([$config, $source, $composer] as $file) {
+                if (file_exists($file)) {
+                    unlink($file);
+                }
+            }
+
+            $this->removeTempDirectory($directory);
+        }
+    }
+
+    public function testMetadataChangesWhenComposerPsr4DirectoryExistenceChanges(): void
+    {
+        $directory = $this->createTempDirectory();
+        $config    = $directory . '/structarmed.php';
+        $source    = $directory . '/Example.php';
+        $composer  = $directory . '/composer.json';
+
+        file_put_contents($config, '<?php return null;');
+        file_put_contents($source, '<?php class Example {}');
+        file_put_contents($composer, '{"autoload":{"psr-4":{"View\\\\":"resources/view/"}}}');
+
+        try {
+            $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory();
+            $metadataBefore               = $analysisCacheMetadataFactory->metadata(
+                $directory,
+                $config,
+                ['src'],
+                [$source]
+            );
+
+            mkdir($directory . '/resources');
+            mkdir($directory . '/resources/view');
+
+            $metadataAfter = $analysisCacheMetadataFactory->metadata(
+                $directory,
+                $config,
+                ['src'],
+                [$source]
+            );
+
+            $this->assertSame($metadataBefore['composerJsonHash'], $metadataAfter['composerJsonHash']);
+            $this->assertNotSame(
+                $metadataBefore['composerPsr4DirectoriesHash'],
+                $metadataAfter['composerPsr4DirectoriesHash']
+            );
+            $this->assertNotSame(
+                $analysisCacheMetadataFactory->key($metadataBefore),
+                $analysisCacheMetadataFactory->key($metadataAfter)
+            );
+        } finally {
+            foreach ([$config, $source, $composer] as $file) {
+                if (file_exists($file)) {
+                    unlink($file);
+                }
+            }
+
+            if (is_dir($directory . '/resources/view')) {
+                rmdir($directory . '/resources/view');
+            }
+
+            if (is_dir($directory . '/resources')) {
+                rmdir($directory . '/resources');
+            }
+
+            $this->removeTempDirectory($directory);
+        }
     }
 
     public function testMetadataIncludesComposerGeneratedVersionHash(): void

--- a/tests/Cli/StructArmedApplicationTest.php
+++ b/tests/Cli/StructArmedApplicationTest.php
@@ -383,6 +383,68 @@ PHP);
         }
     }
 
+    public function testAnalyseCommandInvalidatesCacheWhenComposerPsr4DirectoryIsRemoved(): void
+    {
+        $basePath = $this->createProjectDirectory();
+        mkdir($basePath . '/resources');
+        mkdir($basePath . '/resources/view');
+
+        file_put_contents($basePath . '/composer.json', <<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/",
+            "view\\": "resources/view"
+        }
+    }
+}
+JSON);
+
+        file_put_contents($basePath . '/structarmed.php', <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+
+return Architecture::define()
+    ->withPreset(Preset::PSR4());
+PHP);
+
+        try {
+            [$firstExitCode, $firstOutput] = $this->runApplication(
+                [
+                    'structarmed',
+                    'analyse',
+                    '--config=' . $basePath . '/structarmed.php',
+                    '--clear-cache',
+                    '--no-progress',
+                ],
+                $basePath
+            );
+
+            rmdir($basePath . '/resources/view');
+
+            [$secondExitCode, $secondOutput] = $this->runApplication(
+                [
+                    'structarmed',
+                    'analyse',
+                    '--config=' . $basePath . '/structarmed.php',
+                    '--no-progress',
+                ],
+                $basePath
+            );
+
+            $this->assertSame(0, $firstExitCode, $firstOutput);
+            $this->assertStringContainsString('No violations found', $firstOutput);
+            $this->assertSame(1, $secondExitCode, $secondOutput);
+            $this->assertStringContainsString('PSR-4 directory path(s) [view\\ => resources/view]', $secondOutput);
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
     public function testAnalyseCommandOnlyParsesNewFilesAfterCacheWarmup(): void
     {
         $basePath = $this->createProjectDirectory();
@@ -970,6 +1032,10 @@ PHP;
             unlink($basePath . '/structarmed-baseline.php');
         }
 
+        if (file_exists($basePath . '/composer.json')) {
+            unlink($basePath . '/composer.json');
+        }
+
         foreach (glob($basePath . '/var/cache/structarmed/*.json') ?: [] as $cacheFile) {
             unlink($cacheFile);
         }
@@ -984,6 +1050,14 @@ PHP;
 
         if (is_dir($basePath . '/src')) {
             rmdir($basePath . '/src');
+        }
+
+        if (is_dir($basePath . '/resources/view')) {
+            rmdir($basePath . '/resources/view');
+        }
+
+        if (is_dir($basePath . '/resources')) {
+            rmdir($basePath . '/resources');
         }
 
         if (is_dir($basePath . '/var/cache/structarmed')) {

--- a/tests/Cli/StructArmedApplicationTest.php
+++ b/tests/Cli/StructArmedApplicationTest.php
@@ -439,7 +439,7 @@ PHP);
             $this->assertSame(0, $firstExitCode, $firstOutput);
             $this->assertStringContainsString('No violations found', $firstOutput);
             $this->assertSame(1, $secondExitCode, $secondOutput);
-            $this->assertStringContainsString('PSR-4 directory path(s) [view\\ => resources/view]', $secondOutput);
+            $this->assertStringContainsString('PSR-4 directory path [view\\ => resources/view]', $secondOutput);
         } finally {
             $this->removeTempDirectory($basePath);
         }

--- a/tests/Rule/Composer/Psr4SourcePathsRuleTest.php
+++ b/tests/Rule/Composer/Psr4SourcePathsRuleTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 use function file_put_contents;
+use function mkdir;
 
 #[CoversClass(Psr4SourcePathsRule::class)]
 final class Psr4SourcePathsRuleTest extends TestCase
@@ -33,7 +34,7 @@ final class Psr4SourcePathsRuleTest extends TestCase
         }
     }
 }
-JSON);
+JSON, ['src', 'tests']);
 
         $psr4SourcePathsRule = new Psr4SourcePathsRule(['src', 'tests']);
 
@@ -61,6 +62,27 @@ JSON);
 
         $this->assertInstanceOf(RuleViolation::class, $violation);
         $this->assertStringContainsString('tests', $violation->message);
+    }
+
+    public function testFailsWhenComposerPsr4DirectoryDoesNotExist(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "view\\": "directory/not/exists"
+        }
+    }
+}
+JSON);
+
+        $psr4SourcePathsRule = new Psr4SourcePathsRule(null);
+
+        $violation = $psr4SourcePathsRule->evaluateProject($basePath, Architecture::define());
+
+        $this->assertInstanceOf(RuleViolation::class, $violation);
+        $this->assertStringContainsString('view\\ => directory/not/exists', $violation->message);
+        $this->assertStringContainsString('must exist', $violation->message);
     }
 
     public function testFailsWhenComposerJsonIsMissing(): void
@@ -98,7 +120,7 @@ JSON);
         }
     }
 }
-JSON);
+JSON, ['src', 'tests']);
 
         $psr4SourcePathsRule = new Psr4SourcePathsRule(['src/', 'tests/']);
 
@@ -121,7 +143,7 @@ JSON);
         }
     }
 }
-JSON);
+JSON, ['tests']);
 
         $psr4SourcePathsRule = new Psr4SourcePathsRule(['tests/']);
 
@@ -146,7 +168,7 @@ JSON);
         }
     }
 }
-JSON);
+JSON, ['app', 'tests', 'specs']);
 
         $psr4SourcePathsRule = new Psr4SourcePathsRule(null);
 
@@ -164,10 +186,17 @@ JSON);
         $this->assertSame(['src', 'tests'], $psr4SourcePathsRule->sourcePathsFor($this->makeTempDir()));
     }
 
-    private function makeTempProject(string $composerJson): string
+    /**
+     * @param list<string> $directories
+     */
+    private function makeTempProject(string $composerJson, array $directories = []): string
     {
         $basePath = $this->makeTempDir();
         file_put_contents($basePath . '/composer.json', $composerJson);
+
+        foreach ($directories as $directory) {
+            mkdir($basePath . '/' . $directory, 0777, true);
+        }
 
         return $basePath;
     }

--- a/tests/Rule/Composer/Psr4SourcePathsRuleTest.php
+++ b/tests/Rule/Composer/Psr4SourcePathsRuleTest.php
@@ -70,7 +70,8 @@ JSON);
 {
     "autoload": {
         "psr-4": {
-            "view\\": "directory/not/exists"
+            "view\\": "directory/not/exists",
+            "view2\\": "directory/not/exists2"
         }
     }
 }
@@ -83,6 +84,14 @@ JSON);
         $this->assertInstanceOf(RuleViolation::class, $violation);
         $this->assertStringContainsString('view\\ => directory/not/exists', $violation->message);
         $this->assertStringContainsString('must exist', $violation->message);
+
+        $violations = $psr4SourcePathsRule->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(2, $violations);
+        $this->assertStringContainsString('view\\ => directory/not/exists', $violations[0]->message);
+        $this->assertStringContainsString('view2\\ => directory/not/exists2', $violations[1]->message);
+        $this->assertStringNotContainsString('directory/not/exists2', $violations[0]->message);
+        $this->assertStringNotContainsString('directory/not/exists, view2\\', $violations[0]->message);
     }
 
     public function testFailsWhenComposerJsonIsMissing(): void


### PR DESCRIPTION
When you activate psr4 preset, given the following composer.json:

```json
    "autoload": {
        "psr-4": {
            "view\\": "directory/not/exists",
            "view2\\": "directory/not/exists2"
        }
    },
```

It will show notice:

```bash
StructArmed dev-main — Architecture Enforcement
=================================================

Found 1 violation(s):
─────────────────────────────────────────────────

✗  [psr4.source_paths.must_be_in_composer]
   PSR-4 directory path(s) configured in composer.json autoload or autoload-dev must exist:
      - view\ => directory/not/exists
      - view2\ => directory/not/exists2
   → /Users/samsonasik/www/boundwize/structarmed/composer.json:1
   Layer: Source

─────────────────────────────────────────────────
1 violation(s) found  •  0.01s
```