### PR TITLE
[perf] Improve performance on files finder

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -624,11 +624,7 @@ final readonly class Analyser
 
         /** @var SplFileInfo $file */
         foreach ($iterator as $file) {
-            $realPath = $file->getRealPath();
-
-            if ($realPath !== false) {
-                $files[] = $realPath;
-            }
+            $files[] = $file->getPathname();
         }
 
         return $files;

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -611,21 +611,19 @@ final readonly class Analyser
             new RecursiveCallbackFilterIterator(
                 new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
                 function (SplFileInfo $file) use ($skipPaths): bool {
-                    if (! $file->isDir() && $file->getExtension() !== 'php') {
+                    $isRealDirectory = $file->isDir() && ! $file->isLink();
+                    if (! $isRealDirectory && $file->getExtension() !== 'php') {
                         return false;
                     }
 
                     return ! $this->isSkipped($file->getPathname(), $skipPaths);
                 }
-            )
+            ),
+            RecursiveIteratorIterator::LEAVES_ONLY
         );
 
         /** @var SplFileInfo $file */
         foreach ($iterator as $file) {
-            if (! $file->isFile()) {
-                continue;
-            }
-
             $realPath = $file->getRealPath();
 
             if ($realPath !== false) {

--- a/src/Rule/Rules/File/PhpFileFinder.php
+++ b/src/Rule/Rules/File/PhpFileFinder.php
@@ -53,21 +53,19 @@ final readonly class PhpFileFinder
                 new RecursiveCallbackFilterIterator(
                     new RecursiveDirectoryIterator($fullPath, FilesystemIterator::SKIP_DOTS),
                     function (SplFileInfo $file) use ($normalisedBase, $skipMatchers): bool {
-                        if (! $file->isDir() && $file->getExtension() !== 'php') {
+                        $isRealDirectory = $file->isDir() && ! $file->isLink();
+                        if (! $isRealDirectory && $file->getExtension() !== 'php') {
                             return false;
                         }
 
                         return ! $this->isSkipped($file->getPathname(), $normalisedBase, $skipMatchers);
                     }
-                )
+                ),
+                RecursiveIteratorIterator::LEAVES_ONLY
             );
 
             /** @var SplFileInfo $file */
             foreach ($iterator as $file) {
-                if (! $file->isFile()) {
-                    continue;
-                }
-
                 $files[] = $file->getPathname();
             }
         }

--- a/src/Rule/Rules/File/PhpFileFinder.php
+++ b/src/Rule/Rules/File/PhpFileFinder.php
@@ -13,6 +13,7 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 
 use function array_unique;
+use function array_values;
 use function fnmatch;
 use function is_dir;
 use function ltrim;

--- a/src/Rule/Rules/File/PhpFileFinder.php
+++ b/src/Rule/Rules/File/PhpFileFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Boundwize\StructArmed\Rule\Rules\File;
 
+use AppendIterator;
 use Boundwize\StructArmed\Composer\Psr4PathResolver;
 use FilesystemIterator;
 use RecursiveCallbackFilterIterator;
@@ -11,6 +12,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 
+use function array_unique;
 use function fnmatch;
 use function is_dir;
 use function ltrim;
@@ -38,18 +40,19 @@ final readonly class PhpFileFinder
      */
     public function files(string $basePath, array $skipPaths = []): array
     {
-        $files          = [];
         $normalisedBase = $this->normalisePath($basePath, true);
         $skipMatchers   = $this->compileSkipMatchers($normalisedBase, $skipPaths);
+        $append         = new AppendIterator();
 
-        foreach ($this->sourcePaths ?? $this->psr4PathResolver->paths($basePath) as $sourcePath) {
+        $sourcePaths = array_unique($this->sourcePaths ?? $this->psr4PathResolver->paths($basePath));
+        foreach ($sourcePaths as $sourcePath) {
             $fullPath = rtrim($basePath, '/') . '/' . ltrim($sourcePath, '/');
 
             if (! is_dir($fullPath)) {
                 continue;
             }
 
-            $iterator = new RecursiveIteratorIterator(
+            $append->append(new RecursiveIteratorIterator(
                 new RecursiveCallbackFilterIterator(
                     new RecursiveDirectoryIterator($fullPath, FilesystemIterator::SKIP_DOTS),
                     function (SplFileInfo $file) use ($normalisedBase, $skipMatchers): bool {
@@ -62,15 +65,19 @@ final readonly class PhpFileFinder
                     }
                 ),
                 RecursiveIteratorIterator::LEAVES_ONLY
-            );
-
-            /** @var SplFileInfo $file */
-            foreach ($iterator as $file) {
-                $files[] = $file->getPathname();
-            }
+            ));
         }
 
-        return $files;
+        $files = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($append as $file) {
+            $files[] = $file->getPathname();
+        }
+
+        // ensure nothing duplicated once more
+        // avoid inner directory provided by multiple source paths
+        return array_values(array_unique($files));
     }
 
     /**


### PR DESCRIPTION
- use AppendIterator, iterate once after loop over repeated inner loop
- Make consistent to use getPathname()

Tested run on `vendor` dir for `6161` files.

| Branch | Avg | Min | Max |
|---|---|---|---|
| `clean-up-is-file` | 5234.5ms | 5090ms | 5357ms |
| `main` | 5344.5ms | 5289ms | 5465ms |

