### PR TITLE
Fix resolve filesize() on filename contains null byte

### DIFF
--- a/src/Analyser/Parallel/ParallelClassNodeExtractor.php
+++ b/src/Analyser/Parallel/ParallelClassNodeExtractor.php
@@ -233,7 +233,7 @@ final readonly class ParallelClassNodeExtractor
     {
         $fileSizes = [];
         foreach ($files as $file) {
-            $fileSizes[$file] = filesize($file) ?: 0;
+            $fileSizes[$file] = @filesize($file) ?: 0;
         }
 
         arsort($fileSizes);


### PR DESCRIPTION
Fix PHP warning on unit test:

```
1 test triggered 1 PHP warning:

1) /Users/samsonasik/www/boundwize/structarmed/src/Analyser/Parallel/ParallelClassNodeExtractor.php:236
filesize(): Filename contains null byte

Triggered by:

* Boundwize\StructArmed\Tests\Analyser\Parallel\ParallelClassNodeExtractorTest::testExtractThrowsWhenWorkerFailsDueToNullByteInFilePath
  /Users/samsonasik/www/boundwize/structarmed/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php:197
```