### PR TITLE
Split namespace dependency checks from ClassNode::dependsOn()

### DIFF
--- a/src/Analyser/ClassNode.php
+++ b/src/Analyser/ClassNode.php
@@ -5,17 +5,13 @@ declare(strict_types=1);
 namespace Boundwize\StructArmed\Analyser;
 
 use function array_filter;
-use function class_exists;
 use function end;
-use function enum_exists;
 use function explode;
 use function in_array;
-use function interface_exists;
 use function preg_match;
 use function rtrim;
 use function str_ends_with;
 use function str_starts_with;
-use function trait_exists;
 
 final readonly class ClassNode
 {
@@ -92,30 +88,22 @@ final readonly class ClassNode
         return (bool) preg_match($pattern, $isFullName ? $this->className : $this->shortName());
     }
 
-    public function dependsOn(string $classOrNamespace): bool
+    public function dependsOn(string $class): bool
     {
-        if (in_array($classOrNamespace, $this->dependencies, true)) {
-            return true;
-        }
+        return in_array($class, $this->dependencies, true);
+    }
 
-        $isMayBeClassLike = ! str_ends_with($classOrNamespace, '\\');
-        $namespace        = rtrim($classOrNamespace, '\\') . '\\';
+    public function dependsOnNamespace(string $namespace): bool
+    {
+        $prefix = rtrim($namespace, '\\') . '\\';
 
         foreach ($this->dependencies as $dependency) {
-            if (str_starts_with($dependency, $namespace)) {
-                return ! $this->isLoadedClassLike($classOrNamespace, $isMayBeClassLike);
+            if (str_starts_with($dependency, $prefix)) {
+                return true;
             }
         }
 
         return false;
-    }
-
-    private function isLoadedClassLike(string $name, bool $isMayBeClassLike): bool
-    {
-        return $isMayBeClassLike && (class_exists($name, true)
-            || interface_exists($name, true)
-            || trait_exists($name, true)
-            || enum_exists($name, true));
     }
 
     public function implementsInterface(string $interface): bool

--- a/src/Preset/Presets/MvcPreset.php
+++ b/src/Preset/Presets/MvcPreset.php
@@ -17,6 +17,7 @@ use Boundwize\StructArmed\Rule\Rules\Method\MustHaveReturnTypeRule;
 use Boundwize\StructArmed\Rule\Rules\Usage\MayNotCallFunctionRule;
 use Boundwize\StructArmed\Rule\Rules\Usage\MayNotUseClassRule;
 use Boundwize\StructArmed\Rule\Rules\Usage\MayNotUseLanguageConstructRule;
+use Boundwize\StructArmed\Rule\Rules\Usage\MayNotUseNamespaceRule;
 use Boundwize\StructArmed\Rule\Rules\Usage\MayNotUseSuperglobalsRule;
 use DateTime;
 use PDO;
@@ -54,6 +55,8 @@ final readonly class MvcPreset implements PresetInterface
 
     public const CONTROLLER_NO_PDO = 'mvc.controller.no_pdo';
 
+    public const CONTROLLER_NO_DOCTRINE_ORM = 'mvc.controller.no_doctrine_orm';
+
     public const CONTROLLER_NO_SUPERGLOBALS = 'mvc.controller.no_superglobals';
 
     public const CONTROLLER_MUST_HAVE_RETURN_TYPES = 'mvc.controller.must_have_return_types';
@@ -77,6 +80,8 @@ final readonly class MvcPreset implements PresetInterface
     public const VIEW_MAX_COMPLEXITY = 'mvc.view.max_complexity';
 
     public const VIEW_NO_PDO = 'mvc.view.no_pdo';
+
+    public const VIEW_NO_DOCTRINE_ORM = 'mvc.view.no_doctrine_orm';
 
     public const VIEW_NO_HEADER = 'mvc.view.no_header';
 
@@ -184,6 +189,11 @@ final readonly class MvcPreset implements PresetInterface
         );
 
         $architecture->rule(
+            self::CONTROLLER_NO_DOCTRINE_ORM,
+            new MayNotUseNamespaceRule(layer: 'Controller', forbiddenNamespace: 'Doctrine\\ORM\\')
+        );
+
+        $architecture->rule(
             self::CONTROLLER_NO_SUPERGLOBALS,
             new MayNotUseSuperglobalsRule(layer: 'Controller')
         );
@@ -249,6 +259,11 @@ final readonly class MvcPreset implements PresetInterface
         $architecture->rule(
             self::VIEW_NO_PDO,
             new MayNotUseClassRule(layer: 'View', forbiddenClass: PDO::class)
+        );
+
+        $architecture->rule(
+            self::VIEW_NO_DOCTRINE_ORM,
+            new MayNotUseNamespaceRule(layer: 'View', forbiddenNamespace: 'Doctrine\\ORM\\')
         );
 
         $architecture->rule(

--- a/src/Rule/Rules/Usage/MayNotUseNamespaceRule.php
+++ b/src/Rule/Rules/Usage/MayNotUseNamespaceRule.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Rule\Rules\Usage;
+
+use Boundwize\StructArmed\Analyser\ClassNode;
+use Boundwize\StructArmed\Rule\RuleInterface;
+use Boundwize\StructArmed\Rule\RuleViolation;
+
+use function preg_match;
+use function sprintf;
+
+final readonly class MayNotUseNamespaceRule implements RuleInterface
+{
+    public function __construct(
+        private string $layer,
+        private string $forbiddenNamespace,
+        private ?string $classNamePattern = null,
+    ) {
+    }
+
+    public function appliesTo(ClassNode $classNode): bool
+    {
+        if (! $classNode->isInLayer($this->layer)) {
+            return false;
+        }
+
+        if ($this->classNamePattern !== null) {
+            return (bool) preg_match($this->classNamePattern, $classNode->className);
+        }
+
+        return true;
+    }
+
+    public function evaluate(ClassNode $classNode): ?RuleViolation
+    {
+        if (! $classNode->dependsOnNamespace($this->forbiddenNamespace)) {
+            return null;
+        }
+
+        return new RuleViolation(
+            message:   sprintf(
+                'Class [%s] must not use namespace [%s]',
+                $classNode->className,
+                $this->forbiddenNamespace
+            ),
+            file:      $classNode->file,
+            line:      $classNode->line,
+            className: $classNode->className,
+            layer:     $classNode->layer,
+        );
+    }
+}

--- a/tests/Analyser/ClassNodeTest.php
+++ b/tests/Analyser/ClassNodeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Boundwize\StructArmed\Tests\Analyser;
 
+use App\Foo;
 use Boundwize\StructArmed\Analyser\ClassNode;
 use Boundwize\StructArmed\Analyser\MethodNode;
 use DateTime;
@@ -184,8 +185,12 @@ final class ClassNodeTest extends TestCase
             dependencies: ['App\\Foo\\SomeService'],
         );
 
+        // both class and namespace App\Foo exists
         $this->assertTrue($classNode->dependsOnNamespace('App\\Foo\\'));
-        $this->assertTrue($classNode->dependsOnNamespace('App\\Foo'));
+        $this->assertTrue($classNode->dependsOnNamespace(Foo::class));
+
+        // since class exists, dependsOn returns false since dependencies are ['App\\Foo\\SomeService']
+        $this->assertFalse($classNode->dependsOn(Foo::class));
     }
 
     public function testDependsOnNamespaceMatchesNamespaceBoundaries(): void

--- a/tests/Analyser/ClassNodeTest.php
+++ b/tests/Analyser/ClassNodeTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Boundwize\StructArmed\Tests\Analyser;
 
-use App\Foo;
 use Boundwize\StructArmed\Analyser\ClassNode;
 use Boundwize\StructArmed\Analyser\MethodNode;
 use DateTime;
@@ -104,8 +103,8 @@ final class ClassNodeTest extends TestCase
             languageConstructs: ['exit'],
         );
 
-        $this->assertTrue($classNode->dependsOn('App\\Infrastructure'));
-        $this->assertFalse($classNode->dependsOn('App\\Application'));
+        $this->assertTrue($classNode->dependsOnNamespace('App\\Infrastructure'));
+        $this->assertFalse($classNode->dependsOnNamespace('App\\Application'));
         $this->assertTrue($classNode->implementsInterface('App\\Contracts\\OrderService'));
         $this->assertTrue($classNode->callsFunction('var_dump'));
         $this->assertTrue($classNode->accessesSuperglobals());
@@ -132,7 +131,7 @@ final class ClassNodeTest extends TestCase
         $this->assertFalse($classNode->dependsOn(DateTime::class));
     }
 
-    public function testDependsOnDoesNotTreatLoadedClassAsNamespacePrefix(): void
+    public function testDependsOnDoesNotMatchNamespacePrefix(): void
     {
         $classNode = new ClassNode(
             className:    'App\\Domain\\OrderService',
@@ -148,29 +147,10 @@ final class ClassNodeTest extends TestCase
         );
 
         $this->assertFalse($classNode->dependsOn(self::class));
+        $this->assertTrue($classNode->dependsOnNamespace(self::class));
     }
 
-    public function testDependsOnDoesNotTreatLoadedPsr4ClassAsNamespacePrefix(): void
-    {
-        $classNode = new ClassNode(
-            className:    'App\\Domain\\OrderService',
-            file:         '/src/OrderService.php',
-            line:         5,
-            layer:        'Domain',
-            extends:      null,
-            isAbstract:   false,
-            isFinal:      false,
-            isInterface:  false,
-            isReadonly:   false,
-            dependencies: [ClassNode::class . '\\NestedDependency'],
-        );
-
-        // ClassNode is a PSR-4 class already loaded in memory, so class_exists($name, false)
-        // returns true and dependsOn does not treat it as a namespace prefix
-        $this->assertFalse($classNode->dependsOn(ClassNode::class));
-    }
-
-    public function testDependsOnTreatsUnloadedPsr4NamespaceAsNamespacePrefix(): void
+    public function testDependsOnNamespaceMatchesPrefix(): void
     {
         $classNode = new ClassNode(
             className:    'App\\Domain\\OrderService',
@@ -185,13 +165,11 @@ final class ClassNodeTest extends TestCase
             dependencies: ['App\\Bar\\SomeService'],
         );
 
-        // App\Bar is not registered anywhere, so class_exists returns false even with autoloading,
-        // and dependsOn treats it as a namespace prefix
-        $this->assertTrue($classNode->dependsOn('App\\Bar'));
-        $this->assertFalse($classNode->dependsOn('App\\Baz'));
+        $this->assertTrue($classNode->dependsOnNamespace('App\\Bar'));
+        $this->assertFalse($classNode->dependsOnNamespace('App\\Baz'));
     }
 
-    public function testDependsOnDoesNotTreatLoadedAppFooClassAsNamespacePrefix(): void
+    public function testDependsOnNamespaceAcceptsTrailingBackslash(): void
     {
         $classNode = new ClassNode(
             className:    'App\\Domain\\OrderService',
@@ -206,13 +184,11 @@ final class ClassNodeTest extends TestCase
             dependencies: ['App\\Foo\\SomeService'],
         );
 
-        // App\Foo is registered via classmap; dependsOn triggers autoloading and treats it as a class
-        $this->assertFalse($classNode->dependsOn(Foo::class));
-        // trailing backslash forces namespace treatment regardless of classlike registration
-        $this->assertTrue($classNode->dependsOn('App\\Foo\\'));
+        $this->assertTrue($classNode->dependsOnNamespace('App\\Foo\\'));
+        $this->assertTrue($classNode->dependsOnNamespace('App\\Foo'));
     }
 
-    public function testDependsOnMatchesNamespaceBoundaries(): void
+    public function testDependsOnNamespaceMatchesNamespaceBoundaries(): void
     {
         $classNode = new ClassNode(
             className:    'App\\Domain\\OrderService',
@@ -227,8 +203,8 @@ final class ClassNodeTest extends TestCase
             dependencies: ['Vendor\\PackageExtra\\Service'],
         );
 
-        $this->assertTrue($classNode->dependsOn('Vendor\\PackageExtra'));
-        $this->assertFalse($classNode->dependsOn('Vendor\\Package'));
+        $this->assertTrue($classNode->dependsOnNamespace('Vendor\\PackageExtra'));
+        $this->assertFalse($classNode->dependsOnNamespace('Vendor\\Package'));
     }
 
     public function testConstructorParamCountReturnsConstructorParamsOrZero(): void

--- a/tests/Rule/Usage/MayNotUseNamespaceRuleTest.php
+++ b/tests/Rule/Usage/MayNotUseNamespaceRuleTest.php
@@ -85,6 +85,14 @@ final class MayNotUseNamespaceRuleTest extends TestCase
         $this->assertTrue($mayNotUseNamespaceRule->appliesTo($classNode));
     }
 
+    public function testAppliesToLayerWhenNoPatternConfigured(): void
+    {
+        $mayNotUseNamespaceRule = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
+        $classNode              = $this->makeNode([]);
+
+        $this->assertTrue($mayNotUseNamespaceRule->appliesTo($classNode));
+    }
+
     public function testDoesNotApplyToNonMatchingClassNamePattern(): void
     {
         $mayNotUseNamespaceRule = new MayNotUseNamespaceRule(

--- a/tests/Rule/Usage/MayNotUseNamespaceRuleTest.php
+++ b/tests/Rule/Usage/MayNotUseNamespaceRuleTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Tests\Rule\Usage;
+
+use Boundwize\StructArmed\Analyser\ClassNode;
+use Boundwize\StructArmed\Rule\Rules\Usage\MayNotUseNamespaceRule;
+use Boundwize\StructArmed\Rule\RuleViolation;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MayNotUseNamespaceRule::class)]
+final class MayNotUseNamespaceRuleTest extends TestCase
+{
+    /** @param list<string> $dependencies */
+    private function makeNode(array $dependencies, string $layer = 'Domain'): ClassNode
+    {
+        return new ClassNode(
+            className:    'App\\Domain\\OrderValueObject',
+            file:         '/fake.php',
+            line:         1,
+            layer:        $layer,
+            extends:      null,
+            isAbstract:   false,
+            isFinal:      true,
+            isInterface:  false,
+            isReadonly:   false,
+            dependencies: $dependencies,
+        );
+    }
+
+    public function testPassesWhenNoDepInForbiddenNamespace(): void
+    {
+        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
+        $classNode = $this->makeNode(['App\\Domain\\SomeService']);
+
+        $this->assertNull($rule->evaluate($classNode));
+    }
+
+    public function testViolatesWhenDepIsInForbiddenNamespace(): void
+    {
+        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
+        $classNode = $this->makeNode(['Doctrine\\ORM\\EntityManager']);
+
+        $violation = $rule->evaluate($classNode);
+
+        $this->assertInstanceOf(RuleViolation::class, $violation);
+        $this->assertStringContainsString('Doctrine\\ORM', $violation->message);
+    }
+
+    public function testViolatesWhenForbiddenNamespaceHasTrailingBackslash(): void
+    {
+        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM\\');
+        $classNode = $this->makeNode(['Doctrine\\ORM\\EntityRepository']);
+
+        $this->assertInstanceOf(RuleViolation::class, $rule->evaluate($classNode));
+    }
+
+    public function testPassesWhenDepOnlySharesNamespacePrefix(): void
+    {
+        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
+        $classNode = $this->makeNode(['Doctrine\\ORMExtra\\Something']);
+
+        $this->assertNull($rule->evaluate($classNode));
+    }
+
+    public function testDoesNotApplyToWrongLayer(): void
+    {
+        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
+        $classNode = $this->makeNode(['Doctrine\\ORM\\EntityManager'], layer: 'Infrastructure');
+
+        $this->assertFalse($rule->appliesTo($classNode));
+    }
+
+    public function testAppliesToMatchingClassNamePattern(): void
+    {
+        $rule      = new MayNotUseNamespaceRule(
+            layer: 'Domain',
+            forbiddenNamespace: 'Doctrine\\ORM',
+            classNamePattern: '/ValueObject$/'
+        );
+        $classNode = $this->makeNode([]);
+
+        $this->assertTrue($rule->appliesTo($classNode));
+    }
+
+    public function testDoesNotApplyToNonMatchingClassNamePattern(): void
+    {
+        $rule      = new MayNotUseNamespaceRule(
+            layer: 'Domain',
+            forbiddenNamespace: 'Doctrine\\ORM',
+            classNamePattern: '/Entity$/'
+        );
+        $classNode = $this->makeNode([]);
+
+        $this->assertFalse($rule->appliesTo($classNode));
+    }
+}

--- a/tests/Rule/Usage/MayNotUseNamespaceRuleTest.php
+++ b/tests/Rule/Usage/MayNotUseNamespaceRuleTest.php
@@ -32,18 +32,18 @@ final class MayNotUseNamespaceRuleTest extends TestCase
 
     public function testPassesWhenNoDepInForbiddenNamespace(): void
     {
-        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
-        $classNode = $this->makeNode(['App\\Domain\\SomeService']);
+        $mayNotUseNamespaceRule = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
+        $classNode              = $this->makeNode(['App\\Domain\\SomeService']);
 
-        $this->assertNull($rule->evaluate($classNode));
+        $this->assertNotInstanceOf(RuleViolation::class, $mayNotUseNamespaceRule->evaluate($classNode));
     }
 
     public function testViolatesWhenDepIsInForbiddenNamespace(): void
     {
-        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
-        $classNode = $this->makeNode(['Doctrine\\ORM\\EntityManager']);
+        $mayNotUseNamespaceRule = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
+        $classNode              = $this->makeNode(['Doctrine\\ORM\\EntityManager']);
 
-        $violation = $rule->evaluate($classNode);
+        $violation = $mayNotUseNamespaceRule->evaluate($classNode);
 
         $this->assertInstanceOf(RuleViolation::class, $violation);
         $this->assertStringContainsString('Doctrine\\ORM', $violation->message);
@@ -51,49 +51,49 @@ final class MayNotUseNamespaceRuleTest extends TestCase
 
     public function testViolatesWhenForbiddenNamespaceHasTrailingBackslash(): void
     {
-        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM\\');
-        $classNode = $this->makeNode(['Doctrine\\ORM\\EntityRepository']);
+        $mayNotUseNamespaceRule = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM\\');
+        $classNode              = $this->makeNode(['Doctrine\\ORM\\EntityRepository']);
 
-        $this->assertInstanceOf(RuleViolation::class, $rule->evaluate($classNode));
+        $this->assertInstanceOf(RuleViolation::class, $mayNotUseNamespaceRule->evaluate($classNode));
     }
 
     public function testPassesWhenDepOnlySharesNamespacePrefix(): void
     {
-        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
-        $classNode = $this->makeNode(['Doctrine\\ORMExtra\\Something']);
+        $mayNotUseNamespaceRule = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
+        $classNode              = $this->makeNode(['Doctrine\\ORMExtra\\Something']);
 
-        $this->assertNull($rule->evaluate($classNode));
+        $this->assertNotInstanceOf(RuleViolation::class, $mayNotUseNamespaceRule->evaluate($classNode));
     }
 
     public function testDoesNotApplyToWrongLayer(): void
     {
-        $rule      = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
-        $classNode = $this->makeNode(['Doctrine\\ORM\\EntityManager'], layer: 'Infrastructure');
+        $mayNotUseNamespaceRule = new MayNotUseNamespaceRule(layer: 'Domain', forbiddenNamespace: 'Doctrine\\ORM');
+        $classNode              = $this->makeNode(['Doctrine\\ORM\\EntityManager'], layer: 'Infrastructure');
 
-        $this->assertFalse($rule->appliesTo($classNode));
+        $this->assertFalse($mayNotUseNamespaceRule->appliesTo($classNode));
     }
 
     public function testAppliesToMatchingClassNamePattern(): void
     {
-        $rule      = new MayNotUseNamespaceRule(
+        $mayNotUseNamespaceRule = new MayNotUseNamespaceRule(
             layer: 'Domain',
             forbiddenNamespace: 'Doctrine\\ORM',
             classNamePattern: '/ValueObject$/'
         );
-        $classNode = $this->makeNode([]);
+        $classNode              = $this->makeNode([]);
 
-        $this->assertTrue($rule->appliesTo($classNode));
+        $this->assertTrue($mayNotUseNamespaceRule->appliesTo($classNode));
     }
 
     public function testDoesNotApplyToNonMatchingClassNamePattern(): void
     {
-        $rule      = new MayNotUseNamespaceRule(
+        $mayNotUseNamespaceRule = new MayNotUseNamespaceRule(
             layer: 'Domain',
             forbiddenNamespace: 'Doctrine\\ORM',
             classNamePattern: '/Entity$/'
         );
-        $classNode = $this->makeNode([]);
+        $classNode              = $this->makeNode([]);
 
-        $this->assertFalse($rule->appliesTo($classNode));
+        $this->assertFalse($mayNotUseNamespaceRule->appliesTo($classNode));
     }
 }


### PR DESCRIPTION
## BC break

`dependsOn()` no longer accepts namespace strings.

Use `dependsOnNamespace()` when checking namespace-level dependencies.

## New rule

This PR also adds `MayNotUseNamespaceRule`.

The rule checks that a layer does not depend on classes from a forbidden namespace.

It is wired into the presets as follows:

* `MvcPreset`

  * Controller and View layers may not use `Doctrine\ORM\`

