### PR TITLE
Remove Controller depends on View setup on MvcPreset

### DIFF
--- a/src/Preset/Presets/MvcPreset.php
+++ b/src/Preset/Presets/MvcPreset.php
@@ -32,8 +32,6 @@ final readonly class MvcPreset implements PresetInterface
     // -------------------------------------------------------------------------
 
     // Layer rules
-    public const CONTROLLER_NOT_DEPEND_VIEW = 'mvc.layer.controller_not_depend_view';
-
     public const MODEL_NOT_DEPEND_CONTROLLER = 'mvc.layer.model_not_depend_controller';
 
     public const MODEL_NOT_DEPEND_VIEW = 'mvc.layer.model_not_depend_view';
@@ -119,11 +117,6 @@ final readonly class MvcPreset implements PresetInterface
 
     private function applyLayerRules(Architecture $architecture): self
     {
-        $architecture->rule(
-            self::CONTROLLER_NOT_DEPEND_VIEW,
-            new MayNotDependOnRule(from: 'Controller', to: 'View', toPath: 'View')
-        );
-
         $architecture->rule(
             self::MODEL_NOT_DEPEND_CONTROLLER,
             new MayNotDependOnRule(from: 'Model', to: 'Controller', toPath: 'Controller')

--- a/tests/Preset/PresetTest.php
+++ b/tests/Preset/PresetTest.php
@@ -247,7 +247,6 @@ final class PresetTest extends TestCase
         )->apply($architecture);
 
         $rules = $architecture->getRules();
-        $this->assertArrayHasKey(MvcPreset::CONTROLLER_NOT_DEPEND_VIEW, $rules);
         $this->assertArrayHasKey(MvcPreset::CONTROLLER_NAME_MUST_END_WITH_CONTROLLER, $rules);
         $this->assertArrayHasKey(MvcPreset::CONTROLLER_MAX_COMPLEXITY, $rules);
         $this->assertArrayHasKey(MvcPreset::MODEL_NAME_MUST_NOT_START_WITH_MODEL, $rules);


### PR DESCRIPTION
This is wrong setup, Controller should allow access View, eg:

```php
return new \Laminas\View\Model\ViewModel();
```

while this remove constant, it actually a bug fix.