### PR TITLE
Fix presets with different source paths overwriting each other's Source layer

### DIFF
--- a/src/Preset/Presets/Psr12Preset.php
+++ b/src/Preset/Presets/Psr12Preset.php
@@ -28,19 +28,21 @@ final readonly class Psr12Preset implements PresetInterface
 
     public function apply(Architecture $architecture): void
     {
-        (new Psr1Preset($this->sourcePaths))->apply($architecture);
+        $psr1Preset = new Psr1Preset($this->sourcePaths);
+        $layerName  = $psr1Preset->resolveLayerName($architecture);
+        $psr1Preset->apply($architecture);
 
         $architecture->rule(
             self::METHODS_MUST_DECLARE_VISIBILITY,
-            new MustDeclareMethodVisibilityRule(Psr1Preset::SOURCE_LAYER)
+            new MustDeclareMethodVisibilityRule($layerName)
         );
         $architecture->rule(
             self::CONSTANTS_MUST_DECLARE_VISIBILITY,
-            new MustDeclareConstantVisibilityRule(Psr1Preset::SOURCE_LAYER)
+            new MustDeclareConstantVisibilityRule($layerName)
         );
         $architecture->rule(
             self::PROPERTIES_MUST_DECLARE_VISIBILITY,
-            new MustDeclarePropertyVisibilityRule(Psr1Preset::SOURCE_LAYER)
+            new MustDeclarePropertyVisibilityRule($layerName)
         );
     }
 }

--- a/src/Preset/Presets/Psr15Preset.php
+++ b/src/Preset/Presets/Psr15Preset.php
@@ -11,7 +11,7 @@ use Boundwize\StructArmed\Rule\Rules\Class_\MustImplementInterfaceRule;
 
 final readonly class Psr15Preset implements PresetInterface
 {
-    public const SOURCE_LAYER = 'Source';
+    use ResolvesSourceLayerName;
 
     public const MIDDLEWARE_MUST_IMPLEMENT_MIDDLEWARE_INTERFACE =
         'psr15.middleware.must_implement_middleware_interface';
@@ -39,11 +39,12 @@ final readonly class Psr15Preset implements PresetInterface
 
     public function apply(Architecture $architecture): void
     {
-        $architecture->layer(self::SOURCE_LAYER, $this->sourcePaths ?? []);
+        $layerName = $this->resolveLayerName($architecture);
+        $architecture->layer($layerName, $this->sourcePaths ?? []);
         $architecture->rule(
             self::MIDDLEWARE_MUST_IMPLEMENT_MIDDLEWARE_INTERFACE,
             new MustImplementInterfaceRule(
-                layer: self::SOURCE_LAYER,
+                layer: $layerName,
                 interface: self::MIDDLEWARE_INTERFACE,
                 classNamePattern: '/Middleware$/'
             )
@@ -52,7 +53,7 @@ final readonly class Psr15Preset implements PresetInterface
         $architecture->rule(
             self::HANDLER_MUST_IMPLEMENT_REQUEST_HANDLER_INTERFACE,
             new MustImplementInterfaceRule(
-                layer: self::SOURCE_LAYER,
+                layer: $layerName,
                 interface: self::REQUEST_HANDLER_INTERFACE,
                 classNamePattern: '/Handler$/'
             )
@@ -61,7 +62,7 @@ final readonly class Psr15Preset implements PresetInterface
         $architecture->rule(
             self::MIDDLEWARE_INTERFACE_IMPLEMENTATION_MUST_HAVE_MIDDLEWARE_SUFFIX,
             new ClassImplementingInterfaceMustHaveSuffixRule(
-                layer: self::SOURCE_LAYER,
+                layer: $layerName,
                 interface: self::MIDDLEWARE_INTERFACE,
                 suffix: 'Middleware'
             )
@@ -70,7 +71,7 @@ final readonly class Psr15Preset implements PresetInterface
         $architecture->rule(
             self::REQUEST_HANDLER_INTERFACE_IMPLEMENTATION_MUST_HAVE_HANDLER_SUFFIX,
             new ClassImplementingInterfaceMustHaveSuffixRule(
-                layer: self::SOURCE_LAYER,
+                layer: $layerName,
                 interface: self::REQUEST_HANDLER_INTERFACE,
                 suffix: 'Handler'
             )

--- a/src/Preset/Presets/Psr15Preset.php
+++ b/src/Preset/Presets/Psr15Preset.php
@@ -11,7 +11,7 @@ use Boundwize\StructArmed\Rule\Rules\Class_\MustImplementInterfaceRule;
 
 final readonly class Psr15Preset implements PresetInterface
 {
-    use ResolvesSourceLayerName;
+    use ResolvesSourceLayerNameTrait;
 
     public const MIDDLEWARE_MUST_IMPLEMENT_MIDDLEWARE_INTERFACE =
         'psr15.middleware.must_implement_middleware_interface';

--- a/src/Preset/Presets/Psr1Preset.php
+++ b/src/Preset/Presets/Psr1Preset.php
@@ -18,7 +18,7 @@ use Boundwize\StructArmed\Rule\Rules\Method\MethodNameMustBeCamelCaseRule;
 
 final readonly class Psr1Preset implements PresetInterface
 {
-    use ResolvesSourceLayerName;
+    use ResolvesSourceLayerNameTrait;
 
     public const FILES_MUST_USE_VALID_TAGS = 'psr1.files.must_use_valid_tags';
 

--- a/src/Preset/Presets/Psr1Preset.php
+++ b/src/Preset/Presets/Psr1Preset.php
@@ -18,7 +18,7 @@ use Boundwize\StructArmed\Rule\Rules\Method\MethodNameMustBeCamelCaseRule;
 
 final readonly class Psr1Preset implements PresetInterface
 {
-    public const SOURCE_LAYER = 'Source';
+    use ResolvesSourceLayerName;
 
     public const FILES_MUST_USE_VALID_TAGS = 'psr1.files.must_use_valid_tags';
 
@@ -48,21 +48,23 @@ final readonly class Psr1Preset implements PresetInterface
 
     public function apply(Architecture $architecture): void
     {
-        $architecture->layer(self::SOURCE_LAYER, $this->sourcePaths ?? []);
+        $layerName = $this->resolveLayerName($architecture);
+        $architecture->layer($layerName, $this->sourcePaths ?? []);
+
         $architecture->rule(self::FILES_MUST_USE_VALID_TAGS, new Psr1PhpTagsRule($this->sourcePaths));
         $architecture->rule(self::FILES_MUST_USE_UTF8_WITHOUT_BOM, new Psr1Utf8WithoutBomRule($this->sourcePaths));
         $architecture->rule(
             self::FILES_SHOULD_DECLARE_SYMBOLS_OR_SIDE_EFFECTS,
             new Psr1SymbolsOrSideEffectsRule($this->sourcePaths)
         );
-        $architecture->rule(self::CLASSES_MUST_FOLLOW_PSR4, new Psr4NamespaceRule(self::SOURCE_LAYER));
+        $architecture->rule(self::CLASSES_MUST_FOLLOW_PSR4, new Psr4NamespaceRule($layerName));
         $architecture->rule(self::SOURCE_PATHS_MUST_BE_IN_COMPOSER, new Psr4SourcePathsRule($this->sourcePaths));
         $architecture->rule(self::SOURCE_PATHS_MUST_EXIST_ON_DISK, new Psr4DirectoryExistsRule());
-        $architecture->rule(self::CLASSES_MUST_BE_STUDLY_CAPS, new ClassNameMustBeStudlyCapsRule(self::SOURCE_LAYER));
+        $architecture->rule(self::CLASSES_MUST_BE_STUDLY_CAPS, new ClassNameMustBeStudlyCapsRule($layerName));
         $architecture->rule(
             self::CLASS_CONSTANTS_MUST_BE_UPPER_CASE,
-            new ClassConstantNameMustBeUpperCaseRule(self::SOURCE_LAYER)
+            new ClassConstantNameMustBeUpperCaseRule($layerName)
         );
-        $architecture->rule(self::METHODS_MUST_BE_CAMEL_CASE, new MethodNameMustBeCamelCaseRule(self::SOURCE_LAYER));
+        $architecture->rule(self::METHODS_MUST_BE_CAMEL_CASE, new MethodNameMustBeCamelCaseRule($layerName));
     }
 }

--- a/src/Preset/Presets/Psr4Preset.php
+++ b/src/Preset/Presets/Psr4Preset.php
@@ -12,7 +12,7 @@ use Boundwize\StructArmed\Rule\Rules\Composer\Psr4SourcePathsRule;
 
 final readonly class Psr4Preset implements PresetInterface
 {
-    use ResolvesSourceLayerName;
+    use ResolvesSourceLayerNameTrait;
 
     public const SOURCE_PATHS_MUST_BE_IN_COMPOSER = 'psr4.source_paths.must_be_in_composer';
 

--- a/src/Preset/Presets/Psr4Preset.php
+++ b/src/Preset/Presets/Psr4Preset.php
@@ -12,7 +12,7 @@ use Boundwize\StructArmed\Rule\Rules\Composer\Psr4SourcePathsRule;
 
 final readonly class Psr4Preset implements PresetInterface
 {
-    public const SOURCE_LAYER = 'Source';
+    use ResolvesSourceLayerName;
 
     public const SOURCE_PATHS_MUST_BE_IN_COMPOSER = 'psr4.source_paths.must_be_in_composer';
 
@@ -30,10 +30,12 @@ final readonly class Psr4Preset implements PresetInterface
 
     public function apply(Architecture $architecture): void
     {
-        $architecture->layer(self::SOURCE_LAYER, $this->sourcePaths ?? []);
+        $layerName = $this->resolveLayerName($architecture);
+        $architecture->layer($layerName, $this->sourcePaths ?? []);
+
         $architecture->rule(
             self::CLASSES_MUST_MATCH_COMPOSER,
-            new Psr4NamespaceRule(self::SOURCE_LAYER)
+            new Psr4NamespaceRule($layerName)
         );
         $architecture->rule(
             self::SOURCE_PATHS_MUST_BE_IN_COMPOSER,

--- a/src/Preset/Presets/ResolvesSourceLayerName.php
+++ b/src/Preset/Presets/ResolvesSourceLayerName.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Preset\Presets;
+
+use Boundwize\StructArmed\Architecture;
+
+use function implode;
+
+trait ResolvesSourceLayerName
+{
+    public const SOURCE_LAYER = 'Source';
+
+    public function resolveLayerName(Architecture $architecture): string
+    {
+        $sourcePaths    = $this->sourcePaths ?? [];
+        $existingLayers = $architecture->getLayers();
+
+        if (! isset($existingLayers[self::SOURCE_LAYER])) {
+            return self::SOURCE_LAYER;
+        }
+
+        if ((array) $existingLayers[self::SOURCE_LAYER] === $sourcePaths) {
+            return self::SOURCE_LAYER;
+        }
+
+        return self::SOURCE_LAYER . '[' . implode(',', $sourcePaths) . ']';
+    }
+}

--- a/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
+++ b/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
@@ -10,6 +10,7 @@ use function array_map;
 use function implode;
 use function rtrim;
 use function sort;
+use function str_replace;
 
 trait ResolvesSourceLayerNameTrait
 {
@@ -42,6 +43,6 @@ trait ResolvesSourceLayerNameTrait
      */
     private function normalizePaths(array $paths): array
     {
-        return array_map(static fn (string $path) => rtrim($path, '/') . '/', $paths);
+        return array_map(static fn (string $path) => rtrim(str_replace('\\', '/', $path), '/') . '/', $paths);
     }
 }

--- a/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
+++ b/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
@@ -6,7 +6,9 @@ namespace Boundwize\StructArmed\Preset\Presets;
 
 use Boundwize\StructArmed\Architecture;
 
+use function array_map;
 use function implode;
+use function rtrim;
 use function sort;
 
 trait ResolvesSourceLayerNameTrait
@@ -15,14 +17,14 @@ trait ResolvesSourceLayerNameTrait
 
     public function resolveLayerName(Architecture $architecture): string
     {
-        $sourcePaths    = $this->sourcePaths ?? [];
+        $sourcePaths    = $this->normalizePaths($this->sourcePaths ?? []);
         $existingLayers = $architecture->getLayers();
 
         if (! isset($existingLayers[self::SOURCE_LAYER])) {
             return self::SOURCE_LAYER;
         }
 
-        $existing = (array) $existingLayers[self::SOURCE_LAYER];
+        $existing = $this->normalizePaths((array) $existingLayers[self::SOURCE_LAYER]);
 
         sort($existing);
         sort($sourcePaths);
@@ -32,5 +34,11 @@ trait ResolvesSourceLayerNameTrait
         }
 
         return self::SOURCE_LAYER . '[' . implode(',', $sourcePaths) . ']';
+    }
+
+    /** @param list<string> $paths */
+    private function normalizePaths(array $paths): array
+    {
+        return array_map(static fn (string $path) => rtrim($path, '/') . '/', $paths);
     }
 }

--- a/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
+++ b/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
@@ -43,6 +43,9 @@ trait ResolvesSourceLayerNameTrait
      */
     private function normalizePaths(array $paths): array
     {
-        return array_map(static fn (string $path) => rtrim(str_replace('\\', '/', $path), '/') . '/', $paths);
+        return array_map(
+            static fn (string $path): string => rtrim(str_replace('\\', '/', $path), '/') . '/',
+            $paths
+        );
     }
 }

--- a/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
+++ b/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
@@ -36,9 +36,12 @@ trait ResolvesSourceLayerNameTrait
         return self::SOURCE_LAYER . '[' . implode(',', $sourcePaths) . ']';
     }
 
-    /** @param list<string> $paths */
+    /**
+     * @param list<string> $paths
+     * @return list<string>
+     */
     private function normalizePaths(array $paths): array
     {
-        return array_map(static fn (string $path) => rtrim($path, '/') . '/', $paths);
+        return array_values(array_map(static fn (string $path) => rtrim($path, '/') . '/', $paths));
     }
 }

--- a/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
+++ b/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
@@ -8,7 +8,7 @@ use Boundwize\StructArmed\Architecture;
 
 use function implode;
 
-trait ResolvesSourceLayerName
+trait ResolvesSourceLayerNameTrait
 {
     public const SOURCE_LAYER = 'Source';
 

--- a/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
+++ b/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
@@ -7,7 +7,6 @@ namespace Boundwize\StructArmed\Preset\Presets;
 use Boundwize\StructArmed\Architecture;
 
 use function array_map;
-use function array_values;
 use function implode;
 use function rtrim;
 use function sort;
@@ -43,6 +42,6 @@ trait ResolvesSourceLayerNameTrait
      */
     private function normalizePaths(array $paths): array
     {
-        return array_values(array_map(static fn (string $path) => rtrim($path, '/') . '/', $paths));
+        return array_map(static fn (string $path) => rtrim($path, '/') . '/', $paths);
     }
 }

--- a/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
+++ b/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
@@ -7,6 +7,7 @@ namespace Boundwize\StructArmed\Preset\Presets;
 use Boundwize\StructArmed\Architecture;
 
 use function array_map;
+use function array_values;
 use function implode;
 use function rtrim;
 use function sort;

--- a/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
+++ b/src/Preset/Presets/ResolvesSourceLayerNameTrait.php
@@ -7,6 +7,7 @@ namespace Boundwize\StructArmed\Preset\Presets;
 use Boundwize\StructArmed\Architecture;
 
 use function implode;
+use function sort;
 
 trait ResolvesSourceLayerNameTrait
 {
@@ -21,7 +22,12 @@ trait ResolvesSourceLayerNameTrait
             return self::SOURCE_LAYER;
         }
 
-        if ((array) $existingLayers[self::SOURCE_LAYER] === $sourcePaths) {
+        $existing = (array) $existingLayers[self::SOURCE_LAYER];
+
+        sort($existing);
+        sort($sourcePaths);
+
+        if ($existing === $sourcePaths) {
             return self::SOURCE_LAYER;
         }
 

--- a/tests/Preset/PresetTest.php
+++ b/tests/Preset/PresetTest.php
@@ -262,6 +262,19 @@ final class PresetTest extends TestCase
         $this->assertArrayNotHasKey('Source[src]', $layers);
     }
 
+    public function testSourceLayerIsReusedWhenSourcePathsMatchRegardlessOfSeparator(): void
+    {
+        $architecture = Architecture::define();
+
+        Preset::PSR4(sourcePaths: ['src/'])->apply($architecture);
+        Preset::PSR1(sourcePaths: ['src\\'])->apply($architecture);
+
+        $layers = $architecture->getLayers();
+        $this->assertArrayHasKey('Source', $layers);
+        $this->assertArrayNotHasKey('Source[src/]', $layers);
+        $this->assertArrayNotHasKey('Source[src\\]', $layers);
+    }
+
     public function testSourceLayerIsReusedWhenSourcePathsAreTheSameRegardlessOfOrder(): void
     {
         $architecture = Architecture::define();

--- a/tests/Preset/PresetTest.php
+++ b/tests/Preset/PresetTest.php
@@ -249,6 +249,31 @@ final class PresetTest extends TestCase
         $this->assertSame(['lib/'], $layers['Source[lib/]']);
     }
 
+    public function testSourceLayerIsReusedWhenSourcePathsAreTheSameRegardlessOfOrder(): void
+    {
+        $architecture = Architecture::define();
+
+        Preset::PSR4(sourcePaths: ['lib/', 'src/'])->apply($architecture);
+        Preset::PSR1(sourcePaths: ['src/', 'lib/'])->apply($architecture);
+
+        $layers = $architecture->getLayers();
+        $this->assertArrayHasKey('Source', $layers);
+        $this->assertArrayNotHasKey('Source[lib/,src/]', $layers);
+        $this->assertArrayNotHasKey('Source[src/,lib/]', $layers);
+    }
+
+    public function testDisambiguatedSourceLayerNameIsSortedCanonically(): void
+    {
+        $architecture = Architecture::define();
+
+        Preset::PSR4(sourcePaths: ['src/'])->apply($architecture);
+        Preset::PSR1(sourcePaths: ['tests/', 'lib/'])->apply($architecture);
+
+        $layers = $architecture->getLayers();
+        $this->assertArrayHasKey('Source[lib/,tests/]', $layers);
+        $this->assertArrayNotHasKey('Source[tests/,lib/]', $layers);
+    }
+
     public function testMvcPresetRegistersAllRules(): void
     {
         $architecture = Architecture::define();

--- a/tests/Preset/PresetTest.php
+++ b/tests/Preset/PresetTest.php
@@ -12,7 +12,7 @@ use Boundwize\StructArmed\Preset\Presets\Psr12Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr15Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr1Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr4Preset;
-use Boundwize\StructArmed\Preset\Presets\ResolvesSourceLayerName;
+use Boundwize\StructArmed\Preset\Presets\ResolvesSourceLayerNameTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Psr12Preset::class)]
 #[CoversClass(Psr15Preset::class)]
 #[CoversClass(Psr4Preset::class)]
-#[CoversClass(ResolvesSourceLayerName::class)]
+#[CoversClass(ResolvesSourceLayerNameTrait::class)]
 final class PresetTest extends TestCase
 {
     public function testPsr1PresetRegistersSourceLayerAndRules(): void

--- a/tests/Preset/PresetTest.php
+++ b/tests/Preset/PresetTest.php
@@ -12,6 +12,7 @@ use Boundwize\StructArmed\Preset\Presets\Psr12Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr15Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr1Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr4Preset;
+use Boundwize\StructArmed\Preset\Presets\ResolvesSourceLayerName;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Psr12Preset::class)]
 #[CoversClass(Psr15Preset::class)]
 #[CoversClass(Psr4Preset::class)]
+#[CoversClass(ResolvesSourceLayerName::class)]
 final class PresetTest extends TestCase
 {
     public function testPsr1PresetRegistersSourceLayerAndRules(): void
@@ -233,6 +235,18 @@ final class PresetTest extends TestCase
         $this->assertArrayHasKey(Psr12Preset::METHODS_MUST_DECLARE_VISIBILITY, $rules);
         $this->assertArrayHasKey(Psr12Preset::CONSTANTS_MUST_DECLARE_VISIBILITY, $rules);
         $this->assertArrayHasKey(Psr12Preset::PROPERTIES_MUST_DECLARE_VISIBILITY, $rules);
+    }
+
+    public function testSourceLayerNameIsDisambiguatedWhenPresetsHaveDifferentSourcePaths(): void
+    {
+        $architecture = Architecture::define();
+
+        Preset::PSR4(sourcePaths: ['src/'])->apply($architecture);
+        Preset::PSR1(sourcePaths: ['lib/'])->apply($architecture);
+
+        $layers = $architecture->getLayers();
+        $this->assertArrayHasKey('Source[lib/]', $layers);
+        $this->assertSame(['lib/'], $layers['Source[lib/]']);
     }
 
     public function testMvcPresetRegistersAllRules(): void

--- a/tests/Preset/PresetTest.php
+++ b/tests/Preset/PresetTest.php
@@ -249,6 +249,19 @@ final class PresetTest extends TestCase
         $this->assertSame(['lib/'], $layers['Source[lib/]']);
     }
 
+    public function testSourceLayerIsReusedWhenSourcePathsMatchRegardlessOfTrailingSlash(): void
+    {
+        $architecture = Architecture::define();
+
+        Preset::PSR4(sourcePaths: ['src/'])->apply($architecture);
+        Preset::PSR1(sourcePaths: ['src'])->apply($architecture);
+
+        $layers = $architecture->getLayers();
+        $this->assertArrayHasKey('Source', $layers);
+        $this->assertArrayNotHasKey('Source[src/]', $layers);
+        $this->assertArrayNotHasKey('Source[src]', $layers);
+    }
+
     public function testSourceLayerIsReusedWhenSourcePathsAreTheSameRegardlessOfOrder(): void
     {
         $architecture = Architecture::define();


### PR DESCRIPTION
Given the following configs:

```php
->withPresets(Preset::PSR1(['src']), Preset::PSR4(['tests']));
```

It currently replace each other, which should have each own source to locate per individual preset. 

This PR fix it.