### PR TITLE
Add Psr4RootPathRule and Psr4EmptyNamespacePrefixRule

### DIFF
--- a/src/Composer/Psr4PathResolver.php
+++ b/src/Composer/Psr4PathResolver.php
@@ -160,7 +160,7 @@ final class Psr4PathResolver
         foreach ($paths as $path) {
             $path = rtrim(str_replace('\\', '/', trim($path)), '/');
 
-            if ($path !== '') {
+            if ($path !== '' && $path !== '.') {
                 $normalised[$path] = $path;
             }
         }

--- a/src/Preset/Presets/Psr4Preset.php
+++ b/src/Preset/Presets/Psr4Preset.php
@@ -8,6 +8,7 @@ use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Preset\PresetInterface;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4DirectoryExistsRule;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4NamespaceRule;
+use Boundwize\StructArmed\Rule\Rules\Composer\Psr4RootPathRule;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4SourcePathsRule;
 
 final readonly class Psr4Preset implements PresetInterface
@@ -19,6 +20,8 @@ final readonly class Psr4Preset implements PresetInterface
     public const SOURCE_PATHS_MUST_EXIST_ON_DISK = 'psr4.source_paths.must_exist_on_disk';
 
     public const CLASSES_MUST_MATCH_COMPOSER = 'psr4.classes.must_match_composer';
+
+    public const SOURCE_PATHS_MUST_NOT_BE_ROOT = 'psr4.source_paths.must_not_be_root';
 
     /**
      * @param list<string> $sourcePaths
@@ -42,5 +45,6 @@ final readonly class Psr4Preset implements PresetInterface
             new Psr4SourcePathsRule($this->sourcePaths)
         );
         $architecture->rule(self::SOURCE_PATHS_MUST_EXIST_ON_DISK, new Psr4DirectoryExistsRule());
+        $architecture->rule(self::SOURCE_PATHS_MUST_NOT_BE_ROOT, new Psr4RootPathRule());
     }
 }

--- a/src/Preset/Presets/Psr4Preset.php
+++ b/src/Preset/Presets/Psr4Preset.php
@@ -7,6 +7,7 @@ namespace Boundwize\StructArmed\Preset\Presets;
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Preset\PresetInterface;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4DirectoryExistsRule;
+use Boundwize\StructArmed\Rule\Rules\Composer\Psr4EmptyNamespacePrefixRule;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4NamespaceRule;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4RootPathRule;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4SourcePathsRule;
@@ -22,6 +23,8 @@ final readonly class Psr4Preset implements PresetInterface
     public const CLASSES_MUST_MATCH_COMPOSER = 'psr4.classes.must_match_composer';
 
     public const SOURCE_PATHS_MUST_NOT_BE_ROOT = 'psr4.source_paths.must_not_be_root';
+
+    public const NAMESPACE_PREFIX_MUST_NOT_BE_EMPTY = 'psr4.namespace_prefix.must_not_be_empty';
 
     /**
      * @param list<string> $sourcePaths
@@ -46,5 +49,6 @@ final readonly class Psr4Preset implements PresetInterface
         );
         $architecture->rule(self::SOURCE_PATHS_MUST_EXIST_ON_DISK, new Psr4DirectoryExistsRule());
         $architecture->rule(self::SOURCE_PATHS_MUST_NOT_BE_ROOT, new Psr4RootPathRule());
+        $architecture->rule(self::NAMESPACE_PREFIX_MUST_NOT_BE_EMPTY, new Psr4EmptyNamespacePrefixRule());
     }
 }

--- a/src/Rule/Rules/Composer/Psr4EmptyNamespacePrefixRule.php
+++ b/src/Rule/Rules/Composer/Psr4EmptyNamespacePrefixRule.php
@@ -73,7 +73,8 @@ final readonly class Psr4EmptyNamespacePrefixRule implements MultipleProjectRule
 
                 $violations[] = new RuleViolation(
                     message:   sprintf(
-                        'PSR-4 entry ["%s"] in %s has an empty namespace prefix; declare a specific namespace prefix such as "App\\\\"',
+                        'PSR-4 entry ["%s"] in %s has an empty namespace prefix;'
+                            . ' declare a specific namespace prefix such as "App\\\\"',
                         $namespace,
                         $section
                     ),

--- a/src/Rule/Rules/Composer/Psr4EmptyNamespacePrefixRule.php
+++ b/src/Rule/Rules/Composer/Psr4EmptyNamespacePrefixRule.php
@@ -9,15 +9,15 @@ use Boundwize\StructArmed\Composer\Psr4PathResolver;
 use Boundwize\StructArmed\Rule\MultipleProjectRuleViolationInterface;
 use Boundwize\StructArmed\Rule\RuleViolation;
 
+use function array_keys;
 use function file_exists;
 use function is_array;
 use function is_string;
 use function rtrim;
 use function sprintf;
-use function str_replace;
 use function trim;
 
-final readonly class Psr4RootPathRule implements MultipleProjectRuleViolationInterface
+final readonly class Psr4EmptyNamespacePrefixRule implements MultipleProjectRuleViolationInterface
 {
     public function __construct(
         private Psr4PathResolver $psr4PathResolver = new Psr4PathResolver(),
@@ -62,36 +62,26 @@ final readonly class Psr4RootPathRule implements MultipleProjectRuleViolationInt
                 continue;
             }
 
-            foreach ($psr4 as $namespace => $pathConfig) {
+            foreach (array_keys($psr4) as $namespace) {
                 if (! is_string($namespace)) {
                     continue;
                 }
 
-                foreach ((array) $pathConfig as $path) {
-                    if (! is_string($path)) {
-                        continue;
-                    }
-
-                    $normalisedPath = rtrim(str_replace('\\', '/', trim($path)), '/');
-
-                    if ($normalisedPath !== '.' && $normalisedPath !== '') {
-                        continue;
-                    }
-
-                    $violations[] = new RuleViolation(
-                        message:   sprintf(
-                            'PSR-4 entry ["%s"] => ["%s"] in %s maps to the project root;'
-                                . ' declare a specific directory instead',
-                            $namespace,
-                            $path,
-                            $section
-                        ),
-                        file:      $composerFile,
-                        line:      1,
-                        className: '',
-                        layer:     'Source',
-                    );
+                if (trim($namespace, '\\') !== '') {
+                    continue;
                 }
+
+                $violations[] = new RuleViolation(
+                    message:   sprintf(
+                        'PSR-4 entry ["%s"] in %s has an empty namespace prefix; a valid prefix must end with "\\"',
+                        $namespace,
+                        $section
+                    ),
+                    file:      $composerFile,
+                    line:      1,
+                    className: '',
+                    layer:     'Source',
+                );
             }
         }
 

--- a/src/Rule/Rules/Composer/Psr4EmptyNamespacePrefixRule.php
+++ b/src/Rule/Rules/Composer/Psr4EmptyNamespacePrefixRule.php
@@ -73,7 +73,7 @@ final readonly class Psr4EmptyNamespacePrefixRule implements MultipleProjectRule
 
                 $violations[] = new RuleViolation(
                     message:   sprintf(
-                        'PSR-4 entry ["%s"] in %s has an empty namespace prefix; a valid prefix must end with "\\"',
+                        'PSR-4 entry ["%s"] in %s has an empty namespace prefix; declare a specific namespace prefix such as "App\\\\"',
                         $namespace,
                         $section
                     ),

--- a/src/Rule/Rules/Composer/Psr4RootPathRule.php
+++ b/src/Rule/Rules/Composer/Psr4RootPathRule.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Rule\Rules\Composer;
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Composer\Psr4PathResolver;
+use Boundwize\StructArmed\Rule\MultipleProjectRuleViolationInterface;
+use Boundwize\StructArmed\Rule\RuleViolation;
+
+use function file_exists;
+use function is_array;
+use function is_string;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+use function trim;
+
+final readonly class Psr4RootPathRule implements MultipleProjectRuleViolationInterface
+{
+    public function __construct(
+        private Psr4PathResolver $psr4PathResolver = new Psr4PathResolver(),
+    ) {
+    }
+
+    public function evaluateProject(string $basePath, Architecture $architecture, array $skipPaths = []): ?RuleViolation
+    {
+        return $this->evaluateProjectAll($basePath, $architecture, $skipPaths)[0] ?? null;
+    }
+
+    /**
+     * @return list<RuleViolation>
+     */
+    public function evaluateProjectAll(string $basePath, Architecture $architecture, array $skipPaths = []): array
+    {
+        $composerFile = rtrim($basePath, '/') . '/composer.json';
+
+        if (! file_exists($composerFile)) {
+            return [];
+        }
+
+        $composer = $this->psr4PathResolver->composerConfig($basePath);
+
+        if ($composer === null) {
+            return [];
+        }
+
+        $violations = [];
+
+        foreach (['autoload', 'autoload-dev'] as $section) {
+            $psr4 = $composer[$section]['psr-4'] ?? [];
+
+            if (! is_array($psr4)) {
+                continue;
+            }
+
+            foreach ($psr4 as $namespace => $pathConfig) {
+                if (! is_string($namespace)) {
+                    continue;
+                }
+
+                foreach ((array) $pathConfig as $path) {
+                    if (! is_string($path)) {
+                        continue;
+                    }
+
+                    $normalisedPath = rtrim(str_replace('\\', '/', trim($path)), '/');
+
+                    if ($normalisedPath !== '.' && $normalisedPath !== '') {
+                        continue;
+                    }
+
+                    $violations[] = new RuleViolation(
+                        message:   sprintf(
+                            'PSR-4 entry ["%s"] => ["%s"] in %s maps to the project root; declare a specific directory instead',
+                            $namespace,
+                            $path,
+                            $section
+                        ),
+                        file:      $composerFile,
+                        line:      1,
+                        className: '',
+                        layer:     'Source',
+                    );
+                }
+            }
+        }
+
+        return $violations;
+    }
+}

--- a/tests/Composer/Psr4PathResolverTest.php
+++ b/tests/Composer/Psr4PathResolverTest.php
@@ -61,12 +61,11 @@ JSON);
 
         $psr4PathResolver = new Psr4PathResolver();
 
-        $this->assertSame(['src', 'system', 'tests/system', '.', 'legacy'], $psr4PathResolver->paths($basePath));
+        $this->assertSame(['src', 'system', 'tests/system', 'legacy'], $psr4PathResolver->paths($basePath));
         $this->assertSame(
             [
                 'App\\'         => ['src'],
                 'CodeIgniter\\' => ['system', 'tests/system'],
-                'Root\\'        => ['.'],
                 ''              => ['legacy'],
             ],
             $psr4PathResolver->namespacePaths($basePath)

--- a/tests/Preset/PresetTest.php
+++ b/tests/Preset/PresetTest.php
@@ -220,8 +220,8 @@ final class PresetTest extends TestCase
 
         $rules = $architecture->getRules();
 
-        // PSR-1 has 9 rules, PSR-12 adds 3 more — total must be 13, not 21 (9+9+3 if duplicated)
-        $this->assertCount(13, $rules);
+        // PSR-1 has 9 rules, PSR-12 adds 3 more — total must be 14, not 21 (9+9+3 if duplicated)
+        $this->assertCount(14, $rules);
 
         $this->assertArrayHasKey(Psr1Preset::FILES_MUST_USE_VALID_TAGS, $rules);
         $this->assertArrayHasKey(Psr1Preset::FILES_MUST_USE_UTF8_WITHOUT_BOM, $rules);
@@ -230,6 +230,7 @@ final class PresetTest extends TestCase
         $this->assertArrayHasKey(Psr4Preset::SOURCE_PATHS_MUST_BE_IN_COMPOSER, $rules);
         $this->assertArrayHasKey(Psr4Preset::SOURCE_PATHS_MUST_EXIST_ON_DISK, $rules);
         $this->assertArrayHasKey(Psr4Preset::SOURCE_PATHS_MUST_NOT_BE_ROOT, $rules);
+        $this->assertArrayHasKey(Psr4Preset::NAMESPACE_PREFIX_MUST_NOT_BE_EMPTY, $rules);
         $this->assertArrayHasKey(Psr1Preset::CLASSES_MUST_BE_STUDLY_CAPS, $rules);
         $this->assertArrayHasKey(Psr1Preset::CLASS_CONSTANTS_MUST_BE_UPPER_CASE, $rules);
         $this->assertArrayHasKey(Psr1Preset::METHODS_MUST_BE_CAMEL_CASE, $rules);

--- a/tests/Preset/PresetTest.php
+++ b/tests/Preset/PresetTest.php
@@ -220,7 +220,6 @@ final class PresetTest extends TestCase
 
         $rules = $architecture->getRules();
 
-        // PSR-1 has 9 rules, PSR-12 adds 3 more — total must be 14, not 21 (9+9+3 if duplicated)
         $this->assertCount(14, $rules);
 
         $this->assertArrayHasKey(Psr1Preset::FILES_MUST_USE_VALID_TAGS, $rules);

--- a/tests/Preset/PresetTest.php
+++ b/tests/Preset/PresetTest.php
@@ -220,8 +220,8 @@ final class PresetTest extends TestCase
 
         $rules = $architecture->getRules();
 
-        // PSR-1 has 9 rules, PSR-12 adds 3 more — total must be 12, not 21 (9+9+3 if duplicated)
-        $this->assertCount(12, $rules);
+        // PSR-1 has 9 rules, PSR-12 adds 3 more — total must be 13, not 21 (9+9+3 if duplicated)
+        $this->assertCount(13, $rules);
 
         $this->assertArrayHasKey(Psr1Preset::FILES_MUST_USE_VALID_TAGS, $rules);
         $this->assertArrayHasKey(Psr1Preset::FILES_MUST_USE_UTF8_WITHOUT_BOM, $rules);
@@ -229,6 +229,7 @@ final class PresetTest extends TestCase
         $this->assertArrayHasKey(Psr4Preset::CLASSES_MUST_MATCH_COMPOSER, $rules);
         $this->assertArrayHasKey(Psr4Preset::SOURCE_PATHS_MUST_BE_IN_COMPOSER, $rules);
         $this->assertArrayHasKey(Psr4Preset::SOURCE_PATHS_MUST_EXIST_ON_DISK, $rules);
+        $this->assertArrayHasKey(Psr4Preset::SOURCE_PATHS_MUST_NOT_BE_ROOT, $rules);
         $this->assertArrayHasKey(Psr1Preset::CLASSES_MUST_BE_STUDLY_CAPS, $rules);
         $this->assertArrayHasKey(Psr1Preset::CLASS_CONSTANTS_MUST_BE_UPPER_CASE, $rules);
         $this->assertArrayHasKey(Psr1Preset::METHODS_MUST_BE_CAMEL_CASE, $rules);

--- a/tests/Rule/Composer/Psr4EmptyNamespacePrefixRuleTest.php
+++ b/tests/Rule/Composer/Psr4EmptyNamespacePrefixRuleTest.php
@@ -196,6 +196,17 @@ JSON);
         );
     }
 
+    public function testPassesWhenComposerJsonIsInvalid(): void
+    {
+        $this->assertSame(
+            [],
+            (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll(
+                $this->makeTempProject('{not json'),
+                Architecture::define()
+            )
+        );
+    }
+
     public function testPassesWhenComposerJsonIsMissing(): void
     {
         $this->assertSame(

--- a/tests/Rule/Composer/Psr4EmptyNamespacePrefixRuleTest.php
+++ b/tests/Rule/Composer/Psr4EmptyNamespacePrefixRuleTest.php
@@ -6,6 +6,7 @@ namespace Boundwize\StructArmed\Tests\Rule\Composer;
 
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4EmptyNamespacePrefixRule;
+use Boundwize\StructArmed\Rule\RuleViolation;
 use Boundwize\StructArmed\Tests\Support\TemporaryDirectoryCleanupTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -125,7 +126,8 @@ JSON);
 }
 JSON);
 
-        $this->assertNull(
+        $this->assertNotInstanceOf(
+            RuleViolation::class,
             (new Psr4EmptyNamespacePrefixRule())->evaluateProject($basePath, Architecture::define())
         );
     }
@@ -142,7 +144,8 @@ JSON);
 }
 JSON);
 
-        $this->assertNotNull(
+        $this->assertInstanceOf(
+            RuleViolation::class,
             (new Psr4EmptyNamespacePrefixRule())->evaluateProject($basePath, Architecture::define())
         );
     }

--- a/tests/Rule/Composer/Psr4EmptyNamespacePrefixRuleTest.php
+++ b/tests/Rule/Composer/Psr4EmptyNamespacePrefixRuleTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Tests\Rule\Composer;
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Rule\Rules\Composer\Psr4EmptyNamespacePrefixRule;
+use Boundwize\StructArmed\Tests\Support\TemporaryDirectoryCleanupTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+
+#[CoversClass(Psr4EmptyNamespacePrefixRule::class)]
+final class Psr4EmptyNamespacePrefixRuleTest extends TestCase
+{
+    use TemporaryDirectoryCleanupTrait;
+
+    public function testPassesWhenAllNamespacePrefixesAreValid(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}
+JSON);
+
+        $this->assertSame(
+            [],
+            (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll($basePath, Architecture::define())
+        );
+    }
+
+    public function testViolationForEmptyStringPrefix(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "": "src/"
+        }
+    }
+}
+JSON);
+
+        $violations = (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('""', $violations[0]->message);
+        $this->assertStringContainsString('autoload', $violations[0]->message);
+    }
+
+    public function testViolationForSingleBackslashPrefix(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "\\": "src/"
+        }
+    }
+}
+JSON);
+
+        $violations = (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('autoload', $violations[0]->message);
+    }
+
+    public function testViolationInAutoloadDev(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload-dev": {
+        "psr-4": {
+            "": "tests/"
+        }
+    }
+}
+JSON);
+
+        $violations = (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('autoload-dev', $violations[0]->message);
+    }
+
+    public function testReturnsAllViolationsAcrossBothSections(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "\\": "tests/"
+        }
+    }
+}
+JSON);
+
+        $this->assertCount(
+            2,
+            (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll($basePath, Architecture::define())
+        );
+    }
+
+    public function testEvaluateProjectReturnsNullWhenNoViolations(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}
+JSON);
+
+        $this->assertNull(
+            (new Psr4EmptyNamespacePrefixRule())->evaluateProject($basePath, Architecture::define())
+        );
+    }
+
+    public function testEvaluateProjectReturnsViolationWhenEmptyPrefixFound(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "": "src/"
+        }
+    }
+}
+JSON);
+
+        $this->assertNotNull(
+            (new Psr4EmptyNamespacePrefixRule())->evaluateProject($basePath, Architecture::define())
+        );
+    }
+
+    public function testSkipsWhenAutoloadSectionIsNotArray(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": "invalid"
+}
+JSON);
+
+        $this->assertSame(
+            [],
+            (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll($basePath, Architecture::define())
+        );
+    }
+
+    public function testSkipsWhenPsr4SectionIsNotArray(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": "invalid"
+    }
+}
+JSON);
+
+        $this->assertSame(
+            [],
+            (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll($basePath, Architecture::define())
+        );
+    }
+
+    public function testSkipsNonStringNamespaceKeys(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": ["src/"]
+    }
+}
+JSON);
+
+        $this->assertSame(
+            [],
+            (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll($basePath, Architecture::define())
+        );
+    }
+
+    public function testPassesWhenComposerJsonIsMissing(): void
+    {
+        $this->assertSame(
+            [],
+            (new Psr4EmptyNamespacePrefixRule())->evaluateProjectAll($this->makeTempDir(), Architecture::define())
+        );
+    }
+
+    private function makeTempProject(string $composerJson): string
+    {
+        $basePath = $this->makeTempDir();
+        file_put_contents($basePath . '/composer.json', $composerJson);
+
+        return $basePath;
+    }
+
+    private function makeTempDir(): string
+    {
+        return $this->makeTemporaryDirectory('structarmed-psr4-empty-namespace-prefix-rule');
+    }
+}

--- a/tests/Rule/Composer/Psr4RootPathRuleTest.php
+++ b/tests/Rule/Composer/Psr4RootPathRuleTest.php
@@ -6,6 +6,7 @@ namespace Boundwize\StructArmed\Tests\Rule\Composer;
 
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4RootPathRule;
+use Boundwize\StructArmed\Rule\RuleViolation;
 use Boundwize\StructArmed\Tests\Support\TemporaryDirectoryCleanupTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -133,6 +134,105 @@ JSON);
         $this->assertStringContainsString('"Symfony\\Component\\Form\\"', $violations[0]->message);
         $this->assertStringContainsString('""', $violations[0]->message);
         $this->assertStringContainsString('autoload', $violations[0]->message);
+    }
+
+    public function testEvaluateProjectReturnsNullWhenNoViolations(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}
+JSON);
+
+        $this->assertNotInstanceOf(
+            RuleViolation::class,
+            (new Psr4RootPathRule())->evaluateProject($basePath, Architecture::define())
+        );
+    }
+
+    public function testEvaluateProjectReturnsViolationWhenRootPathFound(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "": "./"
+        }
+    }
+}
+JSON);
+
+        $this->assertInstanceOf(
+            RuleViolation::class,
+            (new Psr4RootPathRule())->evaluateProject($basePath, Architecture::define())
+        );
+    }
+
+    public function testSkipsWhenAutoloadSectionIsNotArray(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": "invalid"
+}
+JSON);
+
+        $this->assertSame(
+            [],
+            (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define())
+        );
+    }
+
+    public function testSkipsWhenPsr4SectionIsNotArray(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": "invalid"
+    }
+}
+JSON);
+
+        $this->assertSame(
+            [],
+            (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define())
+        );
+    }
+
+    public function testSkipsNonStringNamespaceKeys(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": ["./"]
+    }
+}
+JSON);
+
+        $this->assertSame(
+            [],
+            (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define())
+        );
+    }
+
+    public function testSkipsNonStringPathValues(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "Root\\": [false, "."]
+        }
+    }
+}
+JSON);
+
+        $violations = (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(1, $violations);
     }
 
     public function testPassesWhenComposerJsonIsMissing(): void

--- a/tests/Rule/Composer/Psr4RootPathRuleTest.php
+++ b/tests/Rule/Composer/Psr4RootPathRuleTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Tests\Rule\Composer;
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Rule\Rules\Composer\Psr4RootPathRule;
+use Boundwize\StructArmed\Tests\Support\TemporaryDirectoryCleanupTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+
+#[CoversClass(Psr4RootPathRule::class)]
+final class Psr4RootPathRuleTest extends TestCase
+{
+    use TemporaryDirectoryCleanupTrait;
+
+    public function testPassesWhenNoPsr4PathMapsToRoot(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}
+JSON);
+
+        $this->assertSame(
+            [],
+            (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define())
+        );
+    }
+
+    public function testViolationWhenEmptyNamespaceMapsToRoot(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "": "./"
+        }
+    }
+}
+JSON);
+
+        $violations = (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('""', $violations[0]->message);
+        $this->assertStringContainsString('"./"', $violations[0]->message);
+        $this->assertStringContainsString('autoload', $violations[0]->message);
+    }
+
+    public function testViolationWhenNamedNamespaceMapsToRoot(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "Root\\": "."
+        }
+    }
+}
+JSON);
+
+        $violations = (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('"Root\\"', $violations[0]->message);
+        $this->assertStringContainsString('"."', $violations[0]->message);
+        $this->assertStringContainsString('autoload', $violations[0]->message);
+    }
+
+    public function testViolationWhenAutoloadDevMapsToRoot(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload-dev": {
+        "psr-4": {
+            "": "./"
+        }
+    }
+}
+JSON);
+
+        $violations = (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('autoload-dev', $violations[0]->message);
+    }
+
+    public function testReturnsAllViolationsAcrossBothSections(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "": "./"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Root\\": "."
+        }
+    }
+}
+JSON);
+
+        $violations = (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(2, $violations);
+    }
+
+    public function testViolationWhenNamespaceMapsToEmptyStringPath(): void
+    {
+        $basePath = $this->makeTempProject(<<<'JSON'
+{
+    "autoload": {
+        "psr-4": {
+            "Symfony\\Component\\Form\\": ""
+        }
+    }
+}
+JSON);
+
+        $violations = (new Psr4RootPathRule())->evaluateProjectAll($basePath, Architecture::define());
+
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('"Symfony\\Component\\Form\\"', $violations[0]->message);
+        $this->assertStringContainsString('""', $violations[0]->message);
+        $this->assertStringContainsString('autoload', $violations[0]->message);
+    }
+
+    public function testPassesWhenComposerJsonIsMissing(): void
+    {
+        $this->assertSame(
+            [],
+            (new Psr4RootPathRule())->evaluateProjectAll($this->makeTempDir(), Architecture::define())
+        );
+    }
+
+    private function makeTempProject(string $composerJson): string
+    {
+        $basePath = $this->makeTempDir();
+        file_put_contents($basePath . '/composer.json', $composerJson);
+
+        return $basePath;
+    }
+
+    private function makeTempDir(): string
+    {
+        return $this->makeTemporaryDirectory('structarmed-psr4-root-path-rule');
+    }
+}

--- a/tests/Rule/Composer/Psr4RootPathRuleTest.php
+++ b/tests/Rule/Composer/Psr4RootPathRuleTest.php
@@ -235,6 +235,14 @@ JSON);
         $this->assertCount(1, $violations);
     }
 
+    public function testPassesWhenComposerJsonIsInvalid(): void
+    {
+        $this->assertSame(
+            [],
+            (new Psr4RootPathRule())->evaluateProjectAll($this->makeTempProject('{not json'), Architecture::define())
+        );
+    }
+
     public function testPassesWhenComposerJsonIsMissing(): void
     {
         $this->assertSame(


### PR DESCRIPTION
1. Mark these definition as violations:

```json
"psr-4": {
    "App\\"   : "",
    "App2\\"  : "./"
     ""       : ""
     ""       : "./"
}
```

They may cause lookup on the whole `vendor/` as 3rd party, which third party already has its own autoload.

There is condition like in `symfony/` components that uses root as definition, but seems due to read only repo.

https://github.com/symfony/http-kernel/blob/17c7c5a29d2d8710e765f156bb48c86b2a61c3e8/composer.json#L66

2. Also make these definiton as violation

```json
"psr-4": {
    ""   : "src",
   "\\": "src/"
}
```

