### PR TITLE
feat: support +LayerName syntax in ruleset to inherit a layer's allowed dependencies

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -27,6 +27,7 @@ use SplFileInfo;
 use function array_fill_keys;
 use function array_filter;
 use function array_key_exists;
+use function array_merge;
 use function array_unique;
 use function array_values;
 use function array_walk;
@@ -125,7 +126,7 @@ final readonly class Analyser
 
         // Evaluate declarative ruleset alongside class rules, but buffer its
         // violations so report ordering remains class rules before ruleset.
-        $ruleset                    = $architecture->getRuleset();
+        $ruleset                    = $this->expandRuleset($architecture->getRuleset());
         $classViolationSkips        = $architecture->getClassViolationSkips();
         $rulesetSkipPaths           = $architecture->getRulesetSkipPaths();
         $rulesetViolationCollection = new RuleViolationCollection();
@@ -253,6 +254,61 @@ final readonly class Analyser
         $ruleViolationCollection->merge($rulesetViolationCollection);
 
         return $ruleViolationCollection;
+    }
+
+    /**
+     * Expand `+LayerName` references in a ruleset into their concrete allowed layers.
+     *
+     * `+LayerName` means: include `LayerName` itself and all layers that `LayerName` is allowed to depend on.
+     * References to unknown layers expand to nothing. Circular references are skipped.
+     *
+     * @param array<string, list<string>> $ruleset
+     * @return array<string, list<string>>
+     */
+    private function expandRuleset(array $ruleset): array
+    {
+        $resolved = [];
+
+        foreach ($ruleset as $layer => $allowedLayers) {
+            $resolving        = [$layer => true];
+            $resolved[$layer] = $this->expandRulesetLayer($allowedLayers, $ruleset, $resolving);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param list<string>                $allowedLayers
+     * @param array<string, list<string>> $ruleset
+     * @param array<string, true>         $resolving  Layers currently being expanded (circular-reference guard).
+     * @return list<string>
+     */
+    private function expandRulesetLayer(array $allowedLayers, array $ruleset, array $resolving): array
+    {
+        $expanded = [];
+
+        foreach ($allowedLayers as $allowedLayer) {
+            if (! str_starts_with($allowedLayer, '+')) {
+                $expanded[] = $allowedLayer;
+                continue;
+            }
+
+            $referencedLayer = substr($allowedLayer, 1);
+
+            if (isset($resolving[$referencedLayer])) {
+                continue;
+            }
+
+            // Include the referenced layer itself, then recursively its allowed layers.
+            $expanded[]        = $referencedLayer;
+            $referencedAllowed = $ruleset[$referencedLayer] ?? [];
+            $expanded          = array_merge(
+                $expanded,
+                $this->expandRulesetLayer($referencedAllowed, $ruleset, $resolving + [$referencedLayer => true])
+            );
+        }
+
+        return array_values(array_unique($expanded));
     }
 
     /**

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -1290,6 +1290,200 @@ final class AnalyserTest extends TestCase
         $this->assertCount(0, $ruleViolationCollection->forRule('ruleset.HTTP'));
     }
 
+    public function testRulesetPlusLayerSyntaxExpandsAllowedLayers(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/RESTful/Resource.php' => <<<'PHP'
+                <?php
+
+                namespace App\RESTful;
+
+                use App\Format\JsonFormatter;
+                use App\Validation\Validator;
+
+                final class Resource
+                {
+                    public function __construct(
+                        private JsonFormatter $formatter,
+                        private Validator $validator,
+                    ) {}
+                }
+                PHP,
+        ]);
+
+        // RESTful uses +API and +Controller to inherit their allowed layers.
+        // API allows Format; Controller allows Validation — both should be permitted for RESTful.
+        $architecture = Architecture::define()
+            ->layerPattern('RESTful', '/^App\\\\RESTful\\\\.*$/')
+            ->layerPattern('Format', '/^App\\\\Format\\\\.*$/')
+            ->layerPattern('Validation', '/^App\\\\Validation\\\\.*$/')
+            ->layerPattern('API', '/^App\\\\API\\\\.*$/')
+            ->layerPattern('Controller', '/^App\\\\Controller\\\\.*$/')
+            ->ruleset([
+                'API'        => ['Format'],
+                'Controller' => ['Validation'],
+                'RESTful'    => ['+API', '+Controller'],
+            ]);
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['src/']);
+
+        $this->assertFalse($ruleViolationCollection->hasViolations());
+    }
+
+    public function testRulesetPlusLayerSyntaxIncludesTargetLayerAndItsDependents(): void
+    {
+        // +API expands to: API (the layer itself) + Format (what API can depend on)
+        // +Controller expands to: Controller (the layer itself) + Validation (what Controller can depend on)
+        // So RESTful is allowed to depend on: API, Format, Controller, Validation
+        $basePath = $this->makeTempProject([
+            'src/API/Handler.php'          => '<?php namespace App\API; final class Handler {}',
+            'src/Format/JsonFormatter.php' => '<?php namespace App\Format; final class JsonFormatter {}',
+            'src/Controller/Base.php'      => '<?php namespace App\Controller; final class Base {}',
+            'src/Validation/Validator.php' => '<?php namespace App\Validation; final class Validator {}',
+            'src/RESTful/Resource.php'     => <<<'PHP'
+                <?php
+
+                namespace App\RESTful;
+
+                use App\API\Handler;
+                use App\Format\JsonFormatter;
+                use App\Controller\Base;
+                use App\Validation\Validator;
+
+                final class Resource
+                {
+                    public function __construct(
+                        private Handler $handler,
+                        private JsonFormatter $formatter,
+                        private Base $base,
+                        private Validator $validator,
+                    ) {}
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layerPattern('RESTful', '/^App\\\\RESTful\\\\.*$/')
+            ->layerPattern('API', '/^App\\\\API\\\\.*$/')
+            ->layerPattern('Format', '/^App\\\\Format\\\\.*$/')
+            ->layerPattern('Controller', '/^App\\\\Controller\\\\.*$/')
+            ->layerPattern('Validation', '/^App\\\\Validation\\\\.*$/')
+            ->ruleset([
+                'API'        => ['Format'],
+                'Controller' => ['Validation'],
+                'RESTful'    => ['+API', '+Controller'],
+            ]);
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['src/']);
+
+        $this->assertFalse($ruleViolationCollection->hasViolations());
+    }
+
+    public function testRulesetPlusLayerSyntaxStillViolatesDisallowedLayers(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/RESTful/Resource.php' => <<<'PHP'
+                <?php
+
+                namespace App\RESTful;
+
+                use App\Database\QueryBuilder;
+
+                final class Resource
+                {
+                    public function __construct(private QueryBuilder $db) {}
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layerPattern('RESTful', '/^App\\\\RESTful\\\\.*$/')
+            ->layerPattern('Database', '/^App\\\\Database\\\\.*$/')
+            ->layerPattern('API', '/^App\\\\API\\\\.*$/')
+            ->ruleset([
+                'API'     => ['Format'],
+                'RESTful' => ['+API'], // Database not in API's allowed list
+            ]);
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['src/']);
+
+        $this->assertTrue($ruleViolationCollection->hasViolations());
+        $violations = $ruleViolationCollection->forRule('ruleset.RESTful');
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('Database', $violations[0]->message);
+    }
+
+    public function testRulesetPlusLayerSyntaxIgnoresUnknownReference(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/RESTful/Resource.php' => <<<'PHP'
+                <?php
+
+                namespace App\RESTful;
+
+                use App\Database\QueryBuilder;
+
+                final class Resource
+                {
+                    public function __construct(private QueryBuilder $db) {}
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layerPattern('RESTful', '/^App\\\\RESTful\\\\.*$/')
+            ->layerPattern('Database', '/^App\\\\Database\\\\.*$/')
+            ->ruleset([
+                'RESTful' => ['+NonExistentLayer'], // unknown layer expands to nothing
+            ]);
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['src/']);
+
+        $violations = $ruleViolationCollection->forRule('ruleset.RESTful');
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('Database', $violations[0]->message);
+    }
+
+    public function testRulesetPlusLayerSyntaxHandlesCircularReference(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/A/ClassA.php' => <<<'PHP'
+                <?php
+
+                namespace App\A;
+
+                use App\B\ClassB;
+                use App\Database\QueryBuilder;
+
+                final class ClassA
+                {
+                    public function __construct(
+                        private ClassB $b,
+                        private QueryBuilder $qb,
+                    ) {}
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layerPattern('A', '/^App\\\\A\\\\.*$/')
+            ->layerPattern('B', '/^App\\\\B\\\\.*$/')
+            ->layerPattern('Database', '/^App\\\\Database\\\\.*$/')
+            ->ruleset([
+                'A' => ['+B'], // +B expands to: B (the layer itself)
+                'B' => ['+A'], // circular: when expanding +A from inside B, A is guarded
+            ]);
+
+        // Must not hang or throw — circular refs are silently skipped.
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['src/']);
+
+        // +B includes B itself → A may depend on B: no violation for ClassB.
+        // Database is not in the expanded allowed list → violation.
+        $violations = $ruleViolationCollection->forRule('ruleset.A');
+        $this->assertCount(1, $violations);
+        $this->assertStringContainsString('Database', $violations[0]->message);
+    }
+
     public function testMayNotDependOnRuleViolationIsDetectedViaAnalyser(): void
     {
         $basePath = $this->makeTempProject([


### PR DESCRIPTION
Adds support for the `+LayerName` shorthand in ruleset definition.

For example, given the following config:

```php
->ruleset([
    'API'        => ['Format'],
    'Controller' => ['Validation'],
    'RESTful'    => ['+API', '+Controller'],
])
```

It nows merge 2 collection of layer and its allowed dependents, which replace the manual write:

```diff
-'RESTful'    => ['API', 'Format', 'Controller', 'Validation'],
+'RESTful'    => ['+API', '+Controller'],
```

removing the need to duplicate those entries by hand.

Per discussion on https://github.com/codeigniter4/CodeIgniter4/pull/10198#discussion_r3243910103

/cc @paulbalandan @michalsn 