### PR TITLE
Add interface extends analysis support

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -418,7 +418,10 @@ final class Analyser
 
         foreach ($classNodes as $classNode) {
             $dependencyMap[$classNode->className] = $classNode->dependencies;
-            $dependencies                         = $classNode->implements;
+            $dependencies                         = [
+                ...$classNode->implements,
+                ...$classNode->interfaceExtends,
+            ];
 
             if ($classNode->extends !== null) {
                 $dependencies[] = $classNode->extends;

--- a/src/Analyser/ClassCollector.php
+++ b/src/Analyser/ClassCollector.php
@@ -338,15 +338,16 @@ final class ClassCollector extends NodeVisitorAbstract
 
     private function collectClassLike(ClassLike $classLike): void
     {
-        $analysis   = $this->collectClassLikeAnalysis($classLike);
-        $className  = $this->resolveClassName($classLike);
-        $layers     = $this->layerResolver->resolveAll($className, $this->currentFile);
-        $layer      = $this->layerResolver->resolve($className, $this->currentFile);
-        $methods    = $this->collectMethods($classLike, $analysis['complexityByMethodId']);
-        $implements = $this->collectImplements($classLike);
-        $traits     = $this->collectTraits($classLike);
-        $constants  = $this->collectConstants($classLike);
-        $properties = $this->collectProperties($classLike);
+        $analysis         = $this->collectClassLikeAnalysis($classLike);
+        $className        = $this->resolveClassName($classLike);
+        $layers           = $this->layerResolver->resolveAll($className, $this->currentFile);
+        $layer            = $this->layerResolver->resolve($className, $this->currentFile);
+        $methods          = $this->collectMethods($classLike, $analysis['complexityByMethodId']);
+        $implements       = $this->collectImplements($classLike);
+        $interfaceExtends = $this->collectInterfaceExtends($classLike);
+        $traits           = $this->collectTraits($classLike);
+        $constants        = $this->collectConstants($classLike);
+        $properties       = $this->collectProperties($classLike);
 
         $this->nodes[] = new ClassNode(
             className:          $className,
@@ -372,6 +373,7 @@ final class ClassCollector extends NodeVisitorAbstract
             languageConstructs: $analysis['languageConstructs'],
             layers:             $layers,
             isEnum:             $classLike instanceof Enum_,
+            interfaceExtends:   $interfaceExtends,
         );
     }
 
@@ -542,6 +544,24 @@ final class ClassCollector extends NodeVisitorAbstract
         }
 
         return $interfaces;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function collectInterfaceExtends(ClassLike $classLike): array
+    {
+        if (! $classLike instanceof Interface_) {
+            return [];
+        }
+
+        $parents = [];
+
+        foreach ($classLike->extends as $parent) {
+            $parents[] = $parent->toString();
+        }
+
+        return $parents;
     }
 
     /**

--- a/src/Analyser/ClassNode.php
+++ b/src/Analyser/ClassNode.php
@@ -29,6 +29,7 @@ final readonly class ClassNode
      * @param string[]       $superglobals        Superglobals accessed ($_GET, $_POST, etc.)
      * @param string[]       $languageConstructs  Language constructs used (exit, die, etc.)
      * @param list<string>   $layers              All layer names this class belongs to; defaults to [$layer]
+     * @param string[]       $interfaceExtends    Interface names this interface extends
      */
     public function __construct(
         public string $className,
@@ -52,6 +53,7 @@ final readonly class ClassNode
         public array $languageConstructs = [],
         array $layers = [],
         public bool $isEnum = false,
+        public array $interfaceExtends = [],
     ) {
         $this->layers = $layers ?: array_filter([$this->layer]);
     }
@@ -109,6 +111,11 @@ final readonly class ClassNode
     public function implementsInterface(string $interface): bool
     {
         return in_array($interface, $this->implements, true);
+    }
+
+    public function extendsInterface(string $interface): bool
+    {
+        return in_array($interface, $this->interfaceExtends, true);
     }
 
     public function callsFunction(string $function): bool

--- a/src/Cache/AnalysisResultCache.php
+++ b/src/Cache/AnalysisResultCache.php
@@ -329,6 +329,7 @@ final readonly class AnalysisResultCache
             'isReadonly'         => $classNode->isReadonly,
             'dependencies'       => $classNode->dependencies,
             'implements'         => array_values($classNode->implements),
+            'interfaceExtends'   => array_values($classNode->interfaceExtends),
             'traits'             => array_values($classNode->traits),
             'methods'            => array_map($this->methodNodeToArray(...), $classNode->methods),
             'constants'          => array_map($this->constantNodeToArray(...), $classNode->constants),
@@ -362,6 +363,7 @@ final readonly class AnalysisResultCache
         $isReadonly         = $node['isReadonly'] ?? null;
         $dependencies       = $node['dependencies'] ?? null;
         $implements         = $node['implements'] ?? null;
+        $interfaceExtends   = $node['interfaceExtends'] ?? [];
         $traits             = $node['traits'] ?? [];
         $rawMethods         = $node['methods'] ?? null;
         $rawConstants       = $node['constants'] ?? null;
@@ -385,6 +387,7 @@ final readonly class AnalysisResultCache
             || ! is_bool($isReadonly)
             || ! $this->isStringArray($dependencies)
             || ! $this->isStringArray($implements)
+            || ! $this->isStringArray($interfaceExtends)
             || ! $this->isStringArray($traits)
             || ! is_array($rawMethods)
             || ! is_array($rawConstants)
@@ -446,27 +449,28 @@ final readonly class AnalysisResultCache
         }
 
         return new ClassNode(
-            className:     $className,
-            file:          $file,
-            line:          $line,
-            layer:         $layer,
-            extends:       $extends,
-            isAbstract:    $isAbstract,
-            isFinal:       $isFinal,
-            isInterface:   $isInterface,
-            isReadonly:    $isReadonly,
-            isTrait:       $isTrait,
-            dependencies:  array_values($dependencies),
-            implements:    array_values($implements),
-            traits:        array_values($traits),
-            methods:       $methods,
-            constants:     $constants,
-            properties:    $properties,
+            className:          $className,
+            file:               $file,
+            line:               $line,
+            layer:              $layer,
+            extends:            $extends,
+            isAbstract:         $isAbstract,
+            isFinal:            $isFinal,
+            isInterface:        $isInterface,
+            isReadonly:         $isReadonly,
+            isTrait:            $isTrait,
+            dependencies:       array_values($dependencies),
+            implements:         array_values($implements),
+            traits:             array_values($traits),
+            methods:            $methods,
+            constants:          $constants,
+            properties:         $properties,
             functionCalls:      array_values($functionCalls),
             superglobals:       array_values($superglobals),
             languageConstructs: array_values($languageConstructs),
             layers:             array_values($layers),
-            isEnum:        $isEnum,
+            isEnum:             $isEnum,
+            interfaceExtends:   array_values($interfaceExtends),
         );
     }
 

--- a/src/Rule/Rules/Class_/ClassImplementingInterfaceMustHaveSuffixRule.php
+++ b/src/Rule/Rules/Class_/ClassImplementingInterfaceMustHaveSuffixRule.php
@@ -21,9 +21,16 @@ final readonly class ClassImplementingInterfaceMustHaveSuffixRule implements Rul
 
     public function appliesTo(ClassNode $classNode): bool
     {
-        return $classNode->isClass()
-            && $classNode->isInLayer($this->layer)
-            && $classNode->implementsInterface($this->interface);
+        if (! $classNode->isInLayer($this->layer)) {
+            return false;
+        }
+
+        if ($classNode->isClass()) {
+            return $classNode->implementsInterface($this->interface);
+        }
+
+        return $classNode->isInterface
+            && $classNode->extendsInterface($this->interface);
     }
 
     public function evaluate(ClassNode $classNode): ?RuleViolation
@@ -32,10 +39,15 @@ final readonly class ClassImplementingInterfaceMustHaveSuffixRule implements Rul
             return null;
         }
 
+        $declaration = $classNode->isInterface ? 'Interface' : 'Class';
+        $relation    = $classNode->isInterface ? 'extending' : 'implementing';
+
         return new RuleViolation(
             message:   sprintf(
-                'Class [%s] implementing interface [%s] must have suffix [%s]',
+                '%s [%s] %s interface [%s] must have suffix [%s]',
+                $declaration,
                 $classNode->className,
+                $relation,
                 $this->interface,
                 $this->suffix
             ),

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -9,6 +9,7 @@ use Boundwize\StructArmed\Analyser\AnalyserOptions;
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
 use Boundwize\StructArmed\Preset\Preset;
+use Boundwize\StructArmed\Preset\Presets\Psr15Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr1Preset;
 use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
 use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
@@ -309,6 +310,32 @@ final class AnalyserTest extends TestCase
         $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
 
         $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
+    }
+
+    public function testPsr15PresetAcceptsInterfaceExtendingMiddlewareInterfaceWithMiddlewareSuffix(): void
+    {
+        $basePath = $this->makeTempProject([
+            'app/AuthMiddleware.php' => <<<'PHP'
+                <?php
+
+                namespace App;
+
+                interface AuthMiddleware extends \Psr\Http\Server\MiddlewareInterface
+                {
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->withPreset(Preset::PSR15(sourcePaths: ['app/']));
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
+        $ruleKey                 = Psr15Preset::MIDDLEWARE_INTERFACE_IMPLEMENTATION_MUST_HAVE_MIDDLEWARE_SUFFIX;
+
+        $this->assertCount(
+            0,
+            $ruleViolationCollection->forRule($ruleKey)
+        );
     }
 
     public function testDddPresetResolvesConventionalLayersInsidePsr4SourceLayer(): void
@@ -1245,6 +1272,42 @@ final class AnalyserTest extends TestCase
 
         $this->assertCount(2, $violations);
         $this->assertSame(['App\\HTTP\\Response', 'App\\HTTP\\ResponseTrait'], $classes);
+    }
+
+    public function testAnalyserRulesetReportsInterfaceExtendsDependencyViolations(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/HTTP/ResponseInterface.php' => <<<'PHP'
+                <?php
+
+                namespace App\HTTP;
+
+                interface ResponseInterface extends \App\Pager\PagerInterface
+                {
+                }
+                PHP,
+            'src/Pager/PagerInterface.php'   => <<<'PHP'
+                <?php
+
+                namespace App\Pager;
+
+                interface PagerInterface
+                {
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layerPattern('HTTP', '/^App\\\\HTTP\\\\.*$/')
+            ->layerPattern('Pager', '/^App\\\\Pager\\\\.*$/')
+            ->ruleset(['HTTP' => []]);
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['src/']);
+        $violations              = $ruleViolationCollection->forRule('ruleset.HTTP');
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('App\\HTTP\\ResponseInterface', $violations[0]->className);
+        $this->assertStringContainsString('App\\Pager\\PagerInterface', $violations[0]->message);
     }
 
     public function testAnalyserRulesetStopsResolvingCyclicInheritanceDependencies(): void

--- a/tests/Analyser/ClassCollectorTest.php
+++ b/tests/Analyser/ClassCollectorTest.php
@@ -71,6 +71,14 @@ final class ClassCollectorTest extends TestCase
         $this->assertTrue($classNode->isInterface);
     }
 
+    public function testCollectsInterfaceExtends(): void
+    {
+        $classNode = $this->collect('<?php interface FooInterface extends FirstInterface, SecondInterface {}');
+
+        $this->assertTrue($classNode->isInterface);
+        $this->assertSame(['FirstInterface', 'SecondInterface'], $classNode->interfaceExtends);
+    }
+
     public function testCollectsTrait(): void
     {
         $classNode = $this->collect('<?php trait FooTrait {}');

--- a/tests/Analyser/ClassNodeTest.php
+++ b/tests/Analyser/ClassNodeTest.php
@@ -102,11 +102,13 @@ final class ClassNodeTest extends TestCase
             functionCalls:      ['var_dump'],
             superglobals:       ['$_SERVER'],
             languageConstructs: ['exit'],
+            interfaceExtends:   ['App\\Contracts\\BaseOrderService'],
         );
 
         $this->assertTrue($classNode->dependsOnNamespace('App\\Infrastructure'));
         $this->assertFalse($classNode->dependsOnNamespace('App\\Application'));
         $this->assertTrue($classNode->implementsInterface('App\\Contracts\\OrderService'));
+        $this->assertTrue($classNode->extendsInterface('App\\Contracts\\BaseOrderService'));
         $this->assertTrue($classNode->callsFunction('var_dump'));
         $this->assertTrue($classNode->accessesSuperglobals());
         $this->assertTrue($classNode->usesLanguageConstruct('exit'));

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -648,6 +648,100 @@ final class AnalysisResultCacheTest extends TestCase
         }
     }
 
+    public function testClassNodesPreserveInterfaceExtends(): void
+    {
+        $cacheDirectory      = $this->createTempDirectory();
+        $sourceFile          = $cacheDirectory . '/Middleware.php';
+        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+
+        file_put_contents($sourceFile, '<?php interface Middleware extends BaseMiddleware {}');
+
+        $classNodes = [
+            new ClassNode(
+                className:        'App\Middleware',
+                file:             $sourceFile,
+                line:             1,
+                layer:            'Source',
+                extends:          null,
+                isAbstract:       false,
+                isFinal:          false,
+                isInterface:      true,
+                isReadonly:       false,
+                interfaceExtends: ['App\BaseMiddleware'],
+            ),
+        ];
+
+        try {
+            $analysisResultCache->storeClassNodes($sourceFile, 'config', $classNodes);
+            $loaded = $analysisResultCache->loadClassNodes($sourceFile, 'config');
+
+            $this->assertIsArray($loaded);
+            $this->assertSame(['App\BaseMiddleware'], $loaded[0]->interfaceExtends);
+            $this->assertEquals($classNodes, $loaded);
+        } finally {
+            if (file_exists($sourceFile)) {
+                unlink($sourceFile);
+            }
+
+            $this->removeTempDirectory($cacheDirectory);
+        }
+    }
+
+    public function testClassNodesLoadOldCachePayloadWithoutInterfaceExtends(): void
+    {
+        $cacheDirectory      = $this->createTempDirectory();
+        $sourceFile          = $cacheDirectory . '/Foo.php';
+        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+
+        file_put_contents($sourceFile, '<?php class Foo {}');
+
+        try {
+            $this->writeCachePayload($cacheDirectory, [
+                'metadata' => [
+                    'namespace' => 'config',
+                    'file'      => $sourceFile,
+                    'hash'      => hash('xxh128', (string) file_get_contents($sourceFile)),
+                ],
+                'nodes'    => [
+                    [
+                        'className'          => Foo::class,
+                        'file'               => $sourceFile,
+                        'line'               => 1,
+                        'layer'              => 'Source',
+                        'extends'            => null,
+                        'isAbstract'         => false,
+                        'isFinal'            => true,
+                        'isInterface'        => false,
+                        'isTrait'            => false,
+                        'isEnum'             => false,
+                        'isReadonly'         => false,
+                        'dependencies'       => [],
+                        'implements'         => [],
+                        'traits'             => [],
+                        'methods'            => [],
+                        'constants'          => [],
+                        'properties'         => [],
+                        'functionCalls'      => [],
+                        'superglobals'       => [],
+                        'languageConstructs' => [],
+                        'layers'             => [],
+                    ],
+                ],
+            ], 'class-nodes-' . hash('xxh128', "config\0" . $sourceFile) . '.json');
+
+            $loaded = $analysisResultCache->loadClassNodes($sourceFile, 'config');
+
+            $this->assertIsArray($loaded);
+            $this->assertSame([], $loaded[0]->interfaceExtends);
+        } finally {
+            if (file_exists($sourceFile)) {
+                unlink($sourceFile);
+            }
+
+            $this->removeTempDirectory($cacheDirectory);
+        }
+    }
+
     public function testClassNodesPreserveMethodExplicitVisibility(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
@@ -978,6 +1072,36 @@ final class AnalysisResultCacheTest extends TestCase
                         'functionCalls' => [],
                         'superglobals'  => [],
                         'layers'        => [],
+                    ],
+                ],
+            ],
+        ];
+        yield 'node has invalid interfaceExtends field' => [
+            [
+                'nodes' => [
+                    [
+                        'className'          => Foo::class,
+                        'file'               => __FILE__,
+                        'line'               => 1,
+                        'layer'              => null,
+                        'extends'            => null,
+                        'isAbstract'         => false,
+                        'isFinal'            => true,
+                        'isInterface'        => false,
+                        'isTrait'            => false,
+                        'isEnum'             => false,
+                        'isReadonly'         => false,
+                        'dependencies'       => [],
+                        'implements'         => [],
+                        'interfaceExtends'   => [10],
+                        'traits'             => [],
+                        'constants'          => [],
+                        'properties'         => [],
+                        'methods'            => [],
+                        'functionCalls'      => [],
+                        'superglobals'       => [],
+                        'languageConstructs' => [],
+                        'layers'             => [],
                     ],
                 ],
             ],

--- a/tests/Rule/Class_/ClassImplementingInterfaceMustHaveSuffixRuleTest.php
+++ b/tests/Rule/Class_/ClassImplementingInterfaceMustHaveSuffixRuleTest.php
@@ -48,6 +48,44 @@ final class ClassImplementingInterfaceMustHaveSuffixRuleTest extends TestCase
         $this->assertStringContainsString('Middleware', $violation->message);
     }
 
+    public function testPassesWhenInterfaceExtendingInterfaceHasSuffix(): void
+    {
+        $classImplementingInterfaceMustHaveSuffixRule = new ClassImplementingInterfaceMustHaveSuffixRule(
+            layer: 'Source',
+            interface: self::MIDDLEWARE_INTERFACE,
+            suffix: 'Middleware'
+        );
+
+        $violation = $classImplementingInterfaceMustHaveSuffixRule->evaluate($this->makeNode(
+            className:        'App\\Http\\AuthMiddleware',
+            implements:       [],
+            isInterface:      true,
+            interfaceExtends: [self::MIDDLEWARE_INTERFACE]
+        ));
+
+        $this->assertNotInstanceOf(RuleViolation::class, $violation);
+    }
+
+    public function testViolatesWhenInterfaceExtendingInterfaceIsMissingSuffix(): void
+    {
+        $classImplementingInterfaceMustHaveSuffixRule = new ClassImplementingInterfaceMustHaveSuffixRule(
+            layer: 'Source',
+            interface: self::MIDDLEWARE_INTERFACE,
+            suffix: 'Middleware'
+        );
+
+        $violation = $classImplementingInterfaceMustHaveSuffixRule->evaluate($this->makeNode(
+            className:        'App\\Http\\Auth',
+            implements:       [],
+            isInterface:      true,
+            interfaceExtends: [self::MIDDLEWARE_INTERFACE]
+        ));
+
+        $this->assertInstanceOf(RuleViolation::class, $violation);
+        $this->assertStringContainsString('Interface', $violation->message);
+        $this->assertStringContainsString('extending interface', $violation->message);
+    }
+
     public function testAppliesOnlyToClassesInLayerImplementingInterface(): void
     {
         $classImplementingInterfaceMustHaveSuffixRule = new ClassImplementingInterfaceMustHaveSuffixRule(
@@ -74,28 +112,37 @@ final class ClassImplementingInterfaceMustHaveSuffixRuleTest extends TestCase
             implements: [self::MIDDLEWARE_INTERFACE],
             isInterface: true
         )));
+        $this->assertTrue($classImplementingInterfaceMustHaveSuffixRule->appliesTo($this->makeNode(
+            className:        'App\\Http\\AuthMiddleware',
+            implements:       [],
+            isInterface:      true,
+            interfaceExtends: [self::MIDDLEWARE_INTERFACE],
+        )));
     }
 
     /**
      * @param string[] $implements
+     * @param string[] $interfaceExtends
      */
     private function makeNode(
         string $className,
         array $implements,
         string $layer = 'Source',
         bool $isInterface = false,
+        array $interfaceExtends = [],
     ): ClassNode {
         return new ClassNode(
-            className:   $className,
-            file:        '/fake.php',
-            line:        1,
-            layer:       $layer,
-            extends:     null,
-            isAbstract:  false,
-            isFinal:     false,
-            isInterface: $isInterface,
-            isReadonly:  false,
-            implements:  $implements,
+            className:        $className,
+            file:             '/fake.php',
+            line:             1,
+            layer:            $layer,
+            extends:          null,
+            isAbstract:       false,
+            isFinal:          false,
+            isInterface:      $isInterface,
+            isReadonly:       false,
+            implements:       $implements,
+            interfaceExtends: $interfaceExtends,
         );
     }
 }


### PR DESCRIPTION
Track interfaces extended by interface declarations via `ClassNode::interfaceExtends`.

The exact usage is in `ClassImplementingInterfaceMustHaveSuffixRule`, which now applies to interfaces extending the configured interface as well as classes implementing it.

This keeps PSR-15 suffix checks compatible with custom middleware/request-handler interfaces, preserves the new field in the analysis cache with an old-cache fallback, and includes interface inheritance in ruleset dependency checks.