### PR TITLE
[experiment] Add recursive parent/interface lookup to ClassNode

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -574,10 +574,7 @@ final class Analyser
         array $seen,
         bool &$cycleDetected
     ): array {
-        if (
-            isset($parentClassCache[$className])
-            && $this->cachedParentsCanBeUsed($parentClassCache[$className], $seen)
-        ) {
+        if (isset($parentClassCache[$className])) {
             return $parentClassCache[$className];
         }
 
@@ -631,10 +628,7 @@ final class Analyser
         array $seen,
         bool &$cycleDetected
     ): array {
-        if (
-            isset($parentInterfaceCache[$className])
-            && $this->cachedParentsCanBeUsed($parentInterfaceCache[$className], $seen)
-        ) {
+        if (isset($parentInterfaceCache[$className])) {
             return $parentInterfaceCache[$className];
         }
 
@@ -694,22 +688,6 @@ final class Analyser
 
         return $parentInterfaces;
     }
-
-    /**
-     * @param list<string>        $cachedParents
-     * @param array<string, true> $seen
-     */
-    private function cachedParentsCanBeUsed(array $cachedParents, array $seen): bool
-    {
-        foreach ($cachedParents as $cachedParent) {
-            if (isset($seen[$cachedParent])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     /**
      * @param list<string> $files
      * @param array<string, string|list<string>> $layers

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -529,7 +529,7 @@ final class Analyser
                 : [];
             $parentInterfaceMap[$classNode->className] = $classNode->interfaceExtends !== []
                 ? array_values(array_unique([...$classNode->implements, ...$classNode->interfaceExtends]))
-                : $classNode->implements;
+                : array_values($classNode->implements);
         }
 
         foreach ($classNodes as $classNode) {

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -418,7 +418,10 @@ final class Analyser
 
         foreach ($classNodes as $classNode) {
             $dependencyMap[$classNode->className] = $classNode->dependencies;
-            $dependencies                         = $classNode->implements;
+            $dependencies                         = [
+                ...$classNode->implements,
+                ...$classNode->interfaceExtends,
+            ];
 
             if ($classNode->extends !== null) {
                 $dependencies[] = $classNode->extends;

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -518,10 +518,9 @@ final class Analyser
      */
     private function withRecursiveParents(array $classNodes): array
     {
-        $parentClassMap       = [];
-        $parentInterfaceMap   = [];
-        $parentClassCache     = [];
-        $parentInterfaceCache = [];
+        $parentClassMap     = [];
+        $parentInterfaceMap = [];
+        $parentsCache       = [];
 
         foreach ($classNodes as $classNode) {
             $parentClassMap[$classNode->className]     = $classNode->extends !== null
@@ -540,49 +539,48 @@ final class Analyser
                 continue;
             }
 
-            $classCycleDetected     = false;
-            $interfaceCycleDetected = false;
-            $parentClasses          = $this->recursiveParentClasses(
-                $classNode->className,
-                $parentClassMap,
-                $parentClassCache,
-                [$classNode->className => true],
-                $classCycleDetected
-            );
-            $parentInterfaces       = $this->recursiveParentInterfaces(
+            $cycleDetected = false;
+            $result        = $this->recursiveParents(
                 $classNode->className,
                 $parentClassMap,
                 $parentInterfaceMap,
-                $parentInterfaceCache,
+                $parentsCache,
                 [$classNode->className => true],
-                $interfaceCycleDetected
+                $cycleDetected
             );
 
-            $classNode->setRecursiveParents($parentClasses, $parentInterfaces);
+            $classNode->setRecursiveParents($result['classes'], $result['interfaces']);
         }
 
         return $classNodes;
     }
 
     /**
-     * @param array<string, list<string>> $parentClassMap
-     * @param array<string, list<string>> $parentClassCache
-     * @param array<string, true>         $seen
-     * @return list<string>
+     * Single DFS that collects both ancestor classes and transitively implemented/extended
+     * interfaces in one pass, avoiding the double traversal of the parent-class chain that
+     * the previous two-method approach required.
+     *
+     * @param array<string, list<string>>                                        $parentClassMap
+     * @param array<string, list<string>>                                        $parentInterfaceMap
+     * @param array<string, array{classes: list<string>, interfaces: list<string>}> $cache
+     * @param array<string, true>                                                $seen
+     * @return array{classes: list<string>, interfaces: list<string>}
      */
-    private function recursiveParentClasses(
+    private function recursiveParents(
         string $className,
         array $parentClassMap,
-        array &$parentClassCache,
+        array $parentInterfaceMap,
+        array &$cache,
         array $seen,
         bool &$cycleDetected
     ): array {
-        if (isset($parentClassCache[$className])) {
-            return $parentClassCache[$className];
+        if (isset($cache[$className])) {
+            return $cache[$className];
         }
 
-        $parentClassesSet = [];
-        $hasCycle         = false;
+        $classesSet    = [];
+        $interfacesSet = [];
+        $hasCycle      = false;
 
         foreach ($parentClassMap[$className] ?? [] as $parentClass) {
             if (isset($seen[$parentClass])) {
@@ -590,56 +588,27 @@ final class Analyser
                 continue;
             }
 
-            $childHasCycle                  = false;
-            $parentClassesSet[$parentClass] = true;
+            $childHasCycle            = false;
+            $classesSet[$parentClass] = true;
+            $result                   = $this->recursiveParents(
+                $parentClass,
+                $parentClassMap,
+                $parentInterfaceMap,
+                $cache,
+                $seen + [$parentClass => true],
+                $childHasCycle
+            );
 
-            foreach (
-                $this->recursiveParentClasses(
-                    $parentClass,
-                    $parentClassMap,
-                    $parentClassCache,
-                    $seen + [$parentClass => true],
-                    $childHasCycle
-                ) as $ancestor
-            ) {
-                $parentClassesSet[$ancestor] = true;
+            foreach ($result['classes'] as $ancestor) {
+                $classesSet[$ancestor] = true;
+            }
+
+            foreach ($result['interfaces'] as $iface) {
+                $interfacesSet[$iface] = true;
             }
 
             $hasCycle = $hasCycle || $childHasCycle;
         }
-
-        $parentClasses = array_keys($parentClassesSet);
-
-        if (! $hasCycle) {
-            $parentClassCache[$className] = $parentClasses;
-        }
-
-        $cycleDetected = $cycleDetected || $hasCycle;
-
-        return $parentClasses;
-    }
-
-    /**
-     * @param array<string, list<string>> $parentClassMap
-     * @param array<string, list<string>> $parentInterfaceMap
-     * @param array<string, list<string>> $parentInterfaceCache
-     * @param array<string, true>         $seen
-     * @return list<string>
-     */
-    private function recursiveParentInterfaces(
-        string $className,
-        array $parentClassMap,
-        array $parentInterfaceMap,
-        array &$parentInterfaceCache,
-        array $seen,
-        bool &$cycleDetected
-    ): array {
-        if (isset($parentInterfaceCache[$className])) {
-            return $parentInterfaceCache[$className];
-        }
-
-        $parentInterfacesSet = [];
-        $hasCycle            = false;
 
         foreach ($parentInterfaceMap[$className] ?? [] as $parentInterface) {
             if (isset($seen[$parentInterface])) {
@@ -647,58 +616,36 @@ final class Analyser
                 continue;
             }
 
-            $childHasCycle                         = false;
-            $parentInterfacesSet[$parentInterface] = true;
+            $childHasCycle                   = false;
+            $interfacesSet[$parentInterface] = true;
+            $result                          = $this->recursiveParents(
+                $parentInterface,
+                $parentClassMap,
+                $parentInterfaceMap,
+                $cache,
+                $seen + [$parentInterface => true],
+                $childHasCycle
+            );
 
-            foreach (
-                $this->recursiveParentInterfaces(
-                    $parentInterface,
-                    $parentClassMap,
-                    $parentInterfaceMap,
-                    $parentInterfaceCache,
-                    $seen + [$parentInterface => true],
-                    $childHasCycle
-                ) as $ancestor
-            ) {
-                $parentInterfacesSet[$ancestor] = true;
+            foreach ($result['interfaces'] as $ancestor) {
+                $interfacesSet[$ancestor] = true;
             }
 
             $hasCycle = $hasCycle || $childHasCycle;
         }
 
-        foreach ($parentClassMap[$className] ?? [] as $parentClass) {
-            if (isset($seen[$parentClass])) {
-                $hasCycle = true;
-                continue;
-            }
-
-            $childHasCycle = false;
-
-            foreach (
-                $this->recursiveParentInterfaces(
-                    $parentClass,
-                    $parentClassMap,
-                    $parentInterfaceMap,
-                    $parentInterfaceCache,
-                    $seen + [$parentClass => true],
-                    $childHasCycle
-                ) as $ancestor
-            ) {
-                $parentInterfacesSet[$ancestor] = true;
-            }
-
-            $hasCycle = $hasCycle || $childHasCycle;
-        }
-
-        $parentInterfaces = array_keys($parentInterfacesSet);
+        $result = [
+            'classes'    => array_keys($classesSet),
+            'interfaces' => array_keys($interfacesSet),
+        ];
 
         if (! $hasCycle) {
-            $parentInterfaceCache[$className] = $parentInterfaces;
+            $cache[$className] = $result;
         }
 
         $cycleDetected = $cycleDetected || $hasCycle;
 
-        return $parentInterfaces;
+        return $result;
     }
 
     /**

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -29,6 +29,7 @@ use function array_fill_keys;
 use function array_filter;
 use function array_intersect;
 use function array_key_exists;
+use function array_keys;
 use function array_merge;
 use function array_unique;
 use function array_values;
@@ -526,13 +527,19 @@ final class Analyser
             $parentClassMap[$classNode->className]     = $classNode->extends !== null
                 ? [$classNode->extends]
                 : [];
-            $parentInterfaceMap[$classNode->className] = array_values(array_unique([
-                ...$classNode->implements,
-                ...$classNode->interfaceExtends,
-            ]));
+            $parentInterfaceMap[$classNode->className] = $classNode->interfaceExtends !== []
+                ? array_values(array_unique([...$classNode->implements, ...$classNode->interfaceExtends]))
+                : $classNode->implements;
         }
 
         foreach ($classNodes as $classNode) {
+            if (
+                $parentClassMap[$classNode->className] === []
+                && $parentInterfaceMap[$classNode->className] === []
+            ) {
+                continue;
+            }
+
             $classCycleDetected     = false;
             $interfaceCycleDetected = false;
             $parentClasses          = $this->recursiveParentClasses(
@@ -578,8 +585,8 @@ final class Analyser
             return $parentClassCache[$className];
         }
 
-        $parentClasses = [];
-        $hasCycle      = false;
+        $parentClassesSet = [];
+        $hasCycle         = false;
 
         foreach ($parentClassMap[$className] ?? [] as $parentClass) {
             if (isset($seen[$parentClass])) {
@@ -587,22 +594,25 @@ final class Analyser
                 continue;
             }
 
-            $childHasCycle = false;
-            $parentClasses = [
-                ...$parentClasses,
-                $parentClass,
-                ...$this->recursiveParentClasses(
+            $childHasCycle                  = false;
+            $parentClassesSet[$parentClass] = true;
+
+            foreach (
+                $this->recursiveParentClasses(
                     $parentClass,
                     $parentClassMap,
                     $parentClassCache,
                     $seen + [$parentClass => true],
                     $childHasCycle
-                ),
-            ];
-            $hasCycle      = $hasCycle || $childHasCycle;
+                ) as $ancestor
+            ) {
+                $parentClassesSet[$ancestor] = true;
+            }
+
+            $hasCycle = $hasCycle || $childHasCycle;
         }
 
-        $parentClasses = array_values(array_unique($parentClasses));
+        $parentClasses = array_keys($parentClassesSet);
 
         if (! $hasCycle) {
             $parentClassCache[$className] = $parentClasses;
@@ -632,8 +642,8 @@ final class Analyser
             return $parentInterfaceCache[$className];
         }
 
-        $parentInterfaces = [];
-        $hasCycle         = false;
+        $parentInterfacesSet = [];
+        $hasCycle            = false;
 
         foreach ($parentInterfaceMap[$className] ?? [] as $parentInterface) {
             if (isset($seen[$parentInterface])) {
@@ -641,20 +651,23 @@ final class Analyser
                 continue;
             }
 
-            $childHasCycle    = false;
-            $parentInterfaces = [
-                ...$parentInterfaces,
-                $parentInterface,
-                ...$this->recursiveParentInterfaces(
+            $childHasCycle                         = false;
+            $parentInterfacesSet[$parentInterface] = true;
+
+            foreach (
+                $this->recursiveParentInterfaces(
                     $parentInterface,
                     $parentClassMap,
                     $parentInterfaceMap,
                     $parentInterfaceCache,
                     $seen + [$parentInterface => true],
                     $childHasCycle
-                ),
-            ];
-            $hasCycle         = $hasCycle || $childHasCycle;
+                ) as $ancestor
+            ) {
+                $parentInterfacesSet[$ancestor] = true;
+            }
+
+            $hasCycle = $hasCycle || $childHasCycle;
         }
 
         foreach ($parentClassMap[$className] ?? [] as $parentClass) {
@@ -663,22 +676,25 @@ final class Analyser
                 continue;
             }
 
-            $childHasCycle    = false;
-            $parentInterfaces = [
-                ...$parentInterfaces,
-                ...$this->recursiveParentInterfaces(
+            $childHasCycle = false;
+
+            foreach (
+                $this->recursiveParentInterfaces(
                     $parentClass,
                     $parentClassMap,
                     $parentInterfaceMap,
                     $parentInterfaceCache,
                     $seen + [$parentClass => true],
                     $childHasCycle
-                ),
-            ];
-            $hasCycle         = $hasCycle || $childHasCycle;
+                ) as $ancestor
+            ) {
+                $parentInterfacesSet[$ancestor] = true;
+            }
+
+            $hasCycle = $hasCycle || $childHasCycle;
         }
 
-        $parentInterfaces = array_values(array_unique($parentInterfaces));
+        $parentInterfaces = array_keys($parentInterfacesSet);
 
         if (! $hasCycle) {
             $parentInterfaceCache[$className] = $parentInterfaces;

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -517,8 +517,10 @@ final class Analyser
      */
     private function withRecursiveParents(array $classNodes): array
     {
-        $parentClassMap     = [];
-        $parentInterfaceMap = [];
+        $parentClassMap       = [];
+        $parentInterfaceMap   = [];
+        $parentClassCache     = [];
+        $parentInterfaceCache = [];
 
         foreach ($classNodes as $classNode) {
             $parentClassMap[$classNode->className]     = $classNode->extends !== null
@@ -533,6 +535,29 @@ final class Analyser
         $resolvedClassNodes = [];
 
         foreach ($classNodes as $classNode) {
+            $classCycleDetected     = false;
+            $interfaceCycleDetected = false;
+            $parentClasses          = $this->recursiveParentClasses(
+                $classNode->className,
+                $parentClassMap,
+                $parentClassCache,
+                [$classNode->className => true],
+                $classCycleDetected
+            );
+            $parentInterfaces       = $this->recursiveParentInterfaces(
+                $classNode->className,
+                $parentClassMap,
+                $parentInterfaceMap,
+                $parentInterfaceCache,
+                [$classNode->className => true],
+                $interfaceCycleDetected
+            );
+
+            if ($classNode->parentClasses === $parentClasses && $classNode->parentInterfaces === $parentInterfaces) {
+                $resolvedClassNodes[] = $classNode;
+                continue;
+            }
+
             $resolvedClassNodes[] = new ClassNode(
                 className:          $classNode->className,
                 file:               $classNode->file,
@@ -556,17 +581,8 @@ final class Analyser
                 layers:             $classNode->layers,
                 isEnum:             $classNode->isEnum,
                 interfaceExtends:   $classNode->interfaceExtends,
-                parentClasses:      $this->recursiveParentClasses(
-                    $classNode->className,
-                    $parentClassMap,
-                    [$classNode->className => true]
-                ),
-                parentInterfaces:   $this->recursiveParentInterfaces(
-                    $classNode->className,
-                    $parentClassMap,
-                    $parentInterfaceMap,
-                    [$classNode->className => true]
-                ),
+                parentClasses:      $parentClasses,
+                parentInterfaces:   $parentInterfaces,
             );
         }
 
@@ -575,31 +591,63 @@ final class Analyser
 
     /**
      * @param array<string, list<string>> $parentClassMap
+     * @param array<string, list<string>> $parentClassCache
      * @param array<string, true>         $seen
      * @return list<string>
      */
-    private function recursiveParentClasses(string $className, array $parentClassMap, array $seen): array
-    {
+    private function recursiveParentClasses(
+        string $className,
+        array $parentClassMap,
+        array &$parentClassCache,
+        array $seen,
+        bool &$cycleDetected
+    ): array {
+        if (
+            isset($parentClassCache[$className])
+            && $this->cachedParentsCanBeUsed($parentClassCache[$className], $seen)
+        ) {
+            return $parentClassCache[$className];
+        }
+
         $parentClasses = [];
+        $hasCycle      = false;
 
         foreach ($parentClassMap[$className] ?? [] as $parentClass) {
             if (isset($seen[$parentClass])) {
+                $hasCycle = true;
                 continue;
             }
 
-            $parentClasses[] = $parentClass;
-            $parentClasses   = [
+            $childHasCycle = false;
+            $parentClasses = [
                 ...$parentClasses,
-                ...$this->recursiveParentClasses($parentClass, $parentClassMap, $seen + [$parentClass => true]),
+                $parentClass,
+                ...$this->recursiveParentClasses(
+                    $parentClass,
+                    $parentClassMap,
+                    $parentClassCache,
+                    $seen + [$parentClass => true],
+                    $childHasCycle
+                ),
             ];
+            $hasCycle      = $hasCycle || $childHasCycle;
         }
 
-        return array_values(array_unique($parentClasses));
+        $parentClasses = array_values(array_unique($parentClasses));
+
+        if (! $hasCycle) {
+            $parentClassCache[$className] = $parentClasses;
+        }
+
+        $cycleDetected = $cycleDetected || $hasCycle;
+
+        return $parentClasses;
     }
 
     /**
      * @param array<string, list<string>> $parentClassMap
      * @param array<string, list<string>> $parentInterfaceMap
+     * @param array<string, list<string>> $parentInterfaceCache
      * @param array<string, true>         $seen
      * @return list<string>
      */
@@ -607,44 +655,87 @@ final class Analyser
         string $className,
         array $parentClassMap,
         array $parentInterfaceMap,
-        array $seen
+        array &$parentInterfaceCache,
+        array $seen,
+        bool &$cycleDetected
     ): array {
+        if (
+            isset($parentInterfaceCache[$className])
+            && $this->cachedParentsCanBeUsed($parentInterfaceCache[$className], $seen)
+        ) {
+            return $parentInterfaceCache[$className];
+        }
+
         $parentInterfaces = [];
+        $hasCycle         = false;
 
         foreach ($parentInterfaceMap[$className] ?? [] as $parentInterface) {
             if (isset($seen[$parentInterface])) {
+                $hasCycle = true;
                 continue;
             }
 
-            $parentInterfaces[] = $parentInterface;
-            $parentInterfaces   = [
+            $childHasCycle    = false;
+            $parentInterfaces = [
                 ...$parentInterfaces,
+                $parentInterface,
                 ...$this->recursiveParentInterfaces(
                     $parentInterface,
                     $parentClassMap,
                     $parentInterfaceMap,
-                    $seen + [$parentInterface => true]
+                    $parentInterfaceCache,
+                    $seen + [$parentInterface => true],
+                    $childHasCycle
                 ),
             ];
+            $hasCycle         = $hasCycle || $childHasCycle;
         }
 
         foreach ($parentClassMap[$className] ?? [] as $parentClass) {
             if (isset($seen[$parentClass])) {
+                $hasCycle = true;
                 continue;
             }
 
+            $childHasCycle    = false;
             $parentInterfaces = [
                 ...$parentInterfaces,
                 ...$this->recursiveParentInterfaces(
                     $parentClass,
                     $parentClassMap,
                     $parentInterfaceMap,
-                    $seen + [$parentClass => true]
+                    $parentInterfaceCache,
+                    $seen + [$parentClass => true],
+                    $childHasCycle
                 ),
             ];
+            $hasCycle         = $hasCycle || $childHasCycle;
         }
 
-        return array_values(array_unique($parentInterfaces));
+        $parentInterfaces = array_values(array_unique($parentInterfaces));
+
+        if (! $hasCycle) {
+            $parentInterfaceCache[$className] = $parentInterfaces;
+        }
+
+        $cycleDetected = $cycleDetected || $hasCycle;
+
+        return $parentInterfaces;
+    }
+
+    /**
+     * @param list<string>        $cachedParents
+     * @param array<string, true> $seen
+     */
+    private function cachedParentsCanBeUsed(array $cachedParents, array $seen): bool
+    {
+        foreach ($cachedParents as $cachedParent) {
+            if (isset($seen[$cachedParent])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -558,10 +558,6 @@ final class Analyser
                 $interfaceCycleDetected
             );
 
-            if ($classNode->parentClasses === $parentClasses && $classNode->parentInterfaces === $parentInterfaces) {
-                continue;
-            }
-
             $classNode->setRecursiveParents($parentClasses, $parentInterfaces);
         }
 

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -688,6 +688,7 @@ final class Analyser
 
         return $parentInterfaces;
     }
+
     /**
      * @param list<string> $files
      * @param array<string, string|list<string>> $layers

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -532,8 +532,6 @@ final class Analyser
             ]));
         }
 
-        $resolvedClassNodes = [];
-
         foreach ($classNodes as $classNode) {
             $classCycleDetected     = false;
             $interfaceCycleDetected = false;
@@ -554,39 +552,13 @@ final class Analyser
             );
 
             if ($classNode->parentClasses === $parentClasses && $classNode->parentInterfaces === $parentInterfaces) {
-                $resolvedClassNodes[] = $classNode;
                 continue;
             }
 
-            $resolvedClassNodes[] = new ClassNode(
-                className:          $classNode->className,
-                file:               $classNode->file,
-                line:               $classNode->line,
-                layer:              $classNode->layer,
-                extends:            $classNode->extends,
-                isAbstract:         $classNode->isAbstract,
-                isFinal:            $classNode->isFinal,
-                isInterface:        $classNode->isInterface,
-                isReadonly:         $classNode->isReadonly,
-                isTrait:            $classNode->isTrait,
-                dependencies:       $classNode->dependencies,
-                implements:         $classNode->implements,
-                traits:             $classNode->traits,
-                methods:            $classNode->methods,
-                constants:          $classNode->constants,
-                properties:         $classNode->properties,
-                functionCalls:      $classNode->functionCalls,
-                superglobals:       $classNode->superglobals,
-                languageConstructs: $classNode->languageConstructs,
-                layers:             $classNode->layers,
-                isEnum:             $classNode->isEnum,
-                interfaceExtends:   $classNode->interfaceExtends,
-                parentClasses:      $parentClasses,
-                parentInterfaces:   $parentInterfaces,
-            );
+            $classNode->setRecursiveParents($parentClasses, $parentInterfaces);
         }
 
-        return $resolvedClassNodes;
+        return $classNodes;
     }
 
     /**

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -128,6 +128,7 @@ final class Analyser
             $chainLayerResolver,
             $analyserOptions ?? AnalyserOptions::parallel()
         );
+        $classNodes = $this->withRecursiveParents($classNodes);
 
         // Evaluate declarative ruleset alongside class rules, but buffer its
         // violations so report ordering remains class rules before ruleset.
@@ -508,6 +509,142 @@ final class Analyser
         }
 
         return array_values(array_unique($resolvedDependencies));
+    }
+
+    /**
+     * @param list<ClassNode> $classNodes
+     * @return list<ClassNode>
+     */
+    private function withRecursiveParents(array $classNodes): array
+    {
+        $parentClassMap     = [];
+        $parentInterfaceMap = [];
+
+        foreach ($classNodes as $classNode) {
+            $parentClassMap[$classNode->className]     = $classNode->extends !== null
+                ? [$classNode->extends]
+                : [];
+            $parentInterfaceMap[$classNode->className] = array_values(array_unique([
+                ...$classNode->implements,
+                ...$classNode->interfaceExtends,
+            ]));
+        }
+
+        $resolvedClassNodes = [];
+
+        foreach ($classNodes as $classNode) {
+            $resolvedClassNodes[] = new ClassNode(
+                className:          $classNode->className,
+                file:               $classNode->file,
+                line:               $classNode->line,
+                layer:              $classNode->layer,
+                extends:            $classNode->extends,
+                isAbstract:         $classNode->isAbstract,
+                isFinal:            $classNode->isFinal,
+                isInterface:        $classNode->isInterface,
+                isReadonly:         $classNode->isReadonly,
+                isTrait:            $classNode->isTrait,
+                dependencies:       $classNode->dependencies,
+                implements:         $classNode->implements,
+                traits:             $classNode->traits,
+                methods:            $classNode->methods,
+                constants:          $classNode->constants,
+                properties:         $classNode->properties,
+                functionCalls:      $classNode->functionCalls,
+                superglobals:       $classNode->superglobals,
+                languageConstructs: $classNode->languageConstructs,
+                layers:             $classNode->layers,
+                isEnum:             $classNode->isEnum,
+                interfaceExtends:   $classNode->interfaceExtends,
+                parentClasses:      $this->recursiveParentClasses(
+                    $classNode->className,
+                    $parentClassMap,
+                    [$classNode->className => true]
+                ),
+                parentInterfaces:   $this->recursiveParentInterfaces(
+                    $classNode->className,
+                    $parentClassMap,
+                    $parentInterfaceMap,
+                    [$classNode->className => true]
+                ),
+            );
+        }
+
+        return $resolvedClassNodes;
+    }
+
+    /**
+     * @param array<string, list<string>> $parentClassMap
+     * @param array<string, true>         $seen
+     * @return list<string>
+     */
+    private function recursiveParentClasses(string $className, array $parentClassMap, array $seen): array
+    {
+        $parentClasses = [];
+
+        foreach ($parentClassMap[$className] ?? [] as $parentClass) {
+            if (isset($seen[$parentClass])) {
+                continue;
+            }
+
+            $parentClasses[] = $parentClass;
+            $parentClasses   = [
+                ...$parentClasses,
+                ...$this->recursiveParentClasses($parentClass, $parentClassMap, $seen + [$parentClass => true]),
+            ];
+        }
+
+        return array_values(array_unique($parentClasses));
+    }
+
+    /**
+     * @param array<string, list<string>> $parentClassMap
+     * @param array<string, list<string>> $parentInterfaceMap
+     * @param array<string, true>         $seen
+     * @return list<string>
+     */
+    private function recursiveParentInterfaces(
+        string $className,
+        array $parentClassMap,
+        array $parentInterfaceMap,
+        array $seen
+    ): array {
+        $parentInterfaces = [];
+
+        foreach ($parentInterfaceMap[$className] ?? [] as $parentInterface) {
+            if (isset($seen[$parentInterface])) {
+                continue;
+            }
+
+            $parentInterfaces[] = $parentInterface;
+            $parentInterfaces   = [
+                ...$parentInterfaces,
+                ...$this->recursiveParentInterfaces(
+                    $parentInterface,
+                    $parentClassMap,
+                    $parentInterfaceMap,
+                    $seen + [$parentInterface => true]
+                ),
+            ];
+        }
+
+        foreach ($parentClassMap[$className] ?? [] as $parentClass) {
+            if (isset($seen[$parentClass])) {
+                continue;
+            }
+
+            $parentInterfaces = [
+                ...$parentInterfaces,
+                ...$this->recursiveParentInterfaces(
+                    $parentClass,
+                    $parentClassMap,
+                    $parentInterfaceMap,
+                    $seen + [$parentClass => true]
+                ),
+            ];
+        }
+
+        return array_values(array_unique($parentInterfaces));
     }
 
     /**

--- a/src/Analyser/ClassCollector.php
+++ b/src/Analyser/ClassCollector.php
@@ -338,15 +338,16 @@ final class ClassCollector extends NodeVisitorAbstract
 
     private function collectClassLike(ClassLike $classLike): void
     {
-        $analysis   = $this->collectClassLikeAnalysis($classLike);
-        $className  = $this->resolveClassName($classLike);
-        $layers     = $this->layerResolver->resolveAll($className, $this->currentFile);
-        $layer      = $this->layerResolver->resolve($className, $this->currentFile);
-        $methods    = $this->collectMethods($classLike, $analysis['complexityByMethodId']);
-        $implements = $this->collectImplements($classLike);
-        $traits     = $this->collectTraits($classLike);
-        $constants  = $this->collectConstants($classLike);
-        $properties = $this->collectProperties($classLike);
+        $analysis         = $this->collectClassLikeAnalysis($classLike);
+        $className        = $this->resolveClassName($classLike);
+        $layers           = $this->layerResolver->resolveAll($className, $this->currentFile);
+        $layer            = $this->layerResolver->resolve($className, $this->currentFile);
+        $methods          = $this->collectMethods($classLike, $analysis['complexityByMethodId']);
+        $implements       = $this->collectImplements($classLike);
+        $interfaceExtends = $this->collectInterfaceExtends($classLike);
+        $traits           = $this->collectTraits($classLike);
+        $constants        = $this->collectConstants($classLike);
+        $properties       = $this->collectProperties($classLike);
 
         $this->nodes[] = new ClassNode(
             className:          $className,
@@ -372,6 +373,7 @@ final class ClassCollector extends NodeVisitorAbstract
             languageConstructs: $analysis['languageConstructs'],
             layers:             $layers,
             isEnum:             $classLike instanceof Enum_,
+            interfaceExtends:   $interfaceExtends,
         );
     }
 
@@ -542,6 +544,24 @@ final class ClassCollector extends NodeVisitorAbstract
         }
 
         return $interfaces;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function collectInterfaceExtends(ClassLike $classLike): array
+    {
+        if (! $classLike instanceof Interface_) {
+            return [];
+        }
+
+        $parents = [];
+
+        foreach ($classLike->extends as $parent) {
+            $parents[] = $parent->toString();
+        }
+
+        return $parents;
     }
 
     /**

--- a/src/Analyser/ClassNode.php
+++ b/src/Analyser/ClassNode.php
@@ -29,6 +29,7 @@ final readonly class ClassNode
      * @param string[]       $superglobals        Superglobals accessed ($_GET, $_POST, etc.)
      * @param string[]       $languageConstructs  Language constructs used (exit, die, etc.)
      * @param list<string>   $layers              All layer names this class belongs to; defaults to [$layer]
+     * @param string[]       $interfaceExtends    Interface names this interface extends
      */
     public function __construct(
         public string $className,
@@ -52,6 +53,7 @@ final readonly class ClassNode
         public array $languageConstructs = [],
         array $layers = [],
         public bool $isEnum = false,
+        public array $interfaceExtends = [],
     ) {
         $this->layers = $layers ?: array_filter([$this->layer]);
     }
@@ -109,6 +111,11 @@ final readonly class ClassNode
     public function implementsInterface(string $interface): bool
     {
         return in_array($interface, $this->implements, true);
+    }
+
+    public function extendsInterface(string $interface): bool
+    {
+        return in_array($interface, $this->interfaceExtends, true);
     }
 
     public function callsFunction(string $function): bool

--- a/src/Analyser/ClassNode.php
+++ b/src/Analyser/ClassNode.php
@@ -30,6 +30,8 @@ final readonly class ClassNode
      * @param string[]       $languageConstructs  Language constructs used (exit, die, etc.)
      * @param list<string>   $layers              All layer names this class belongs to; defaults to [$layer]
      * @param string[]       $interfaceExtends    Interface names this interface extends
+     * @param list<string>   $parentClasses       Direct and transitive parent class names
+     * @param list<string>   $parentInterfaces    Direct and transitive implemented or extended interface names
      */
     public function __construct(
         public string $className,
@@ -54,6 +56,8 @@ final readonly class ClassNode
         array $layers = [],
         public bool $isEnum = false,
         public array $interfaceExtends = [],
+        public array $parentClasses = [],
+        public array $parentInterfaces = [],
     ) {
         $this->layers = $layers ?: array_filter([$this->layer]);
     }
@@ -110,12 +114,20 @@ final readonly class ClassNode
 
     public function implementsInterface(string $interface): bool
     {
-        return in_array($interface, $this->implements, true);
+        return in_array($interface, $this->implements, true)
+            || in_array($interface, $this->parentInterfaces, true);
+    }
+
+    public function extendsClass(string $class): bool
+    {
+        return $this->extends === $class
+            || in_array($class, $this->parentClasses, true);
     }
 
     public function extendsInterface(string $interface): bool
     {
-        return in_array($interface, $this->interfaceExtends, true);
+        return in_array($interface, $this->interfaceExtends, true)
+            || in_array($interface, $this->parentInterfaces, true);
     }
 
     public function callsFunction(string $function): bool

--- a/src/Analyser/ClassNode.php
+++ b/src/Analyser/ClassNode.php
@@ -13,10 +13,10 @@ use function rtrim;
 use function str_ends_with;
 use function str_starts_with;
 
-final readonly class ClassNode
+final class ClassNode
 {
     /** @var list<string> */
-    public array $layers;
+    public readonly array $layers;
 
     /**
      * @param list<string>   $dependencies        Fully-qualified class names this class depends on
@@ -34,32 +34,42 @@ final readonly class ClassNode
      * @param list<string>   $parentInterfaces    Direct and transitive implemented or extended interface names
      */
     public function __construct(
-        public string $className,
-        public string $file,
-        public int $line,
-        public ?string $layer,
-        public ?string $extends,
-        public bool $isAbstract,
-        public bool $isFinal,
-        public bool $isInterface,
-        public bool $isReadonly,
-        public bool $isTrait = false,
-        public array $dependencies = [],
-        public array $implements = [],
-        public array $traits = [],
-        public array $methods = [],
-        public array $constants = [],
-        public array $properties = [],
-        public array $functionCalls = [],
-        public array $superglobals = [],
-        public array $languageConstructs = [],
+        public readonly string $className,
+        public readonly string $file,
+        public readonly int $line,
+        public readonly ?string $layer,
+        public readonly ?string $extends,
+        public readonly bool $isAbstract,
+        public readonly bool $isFinal,
+        public readonly bool $isInterface,
+        public readonly bool $isReadonly,
+        public readonly bool $isTrait = false,
+        public readonly array $dependencies = [],
+        public readonly array $implements = [],
+        public readonly array $traits = [],
+        public readonly array $methods = [],
+        public readonly array $constants = [],
+        public readonly array $properties = [],
+        public readonly array $functionCalls = [],
+        public readonly array $superglobals = [],
+        public readonly array $languageConstructs = [],
         array $layers = [],
-        public bool $isEnum = false,
-        public array $interfaceExtends = [],
+        public readonly bool $isEnum = false,
+        public readonly array $interfaceExtends = [],
         public array $parentClasses = [],
         public array $parentInterfaces = [],
     ) {
         $this->layers = $layers ?: array_filter([$this->layer]);
+    }
+
+    /**
+     * @param list<string> $parentClasses
+     * @param list<string> $parentInterfaces
+     */
+    public function setRecursiveParents(array $parentClasses, array $parentInterfaces): void
+    {
+        $this->parentClasses    = $parentClasses;
+        $this->parentInterfaces = $parentInterfaces;
     }
 
     public function shortName(): string

--- a/src/Cache/AnalysisResultCache.php
+++ b/src/Cache/AnalysisResultCache.php
@@ -329,6 +329,7 @@ final readonly class AnalysisResultCache
             'isReadonly'         => $classNode->isReadonly,
             'dependencies'       => $classNode->dependencies,
             'implements'         => array_values($classNode->implements),
+            'interfaceExtends'   => array_values($classNode->interfaceExtends),
             'traits'             => array_values($classNode->traits),
             'methods'            => array_map($this->methodNodeToArray(...), $classNode->methods),
             'constants'          => array_map($this->constantNodeToArray(...), $classNode->constants),
@@ -362,6 +363,7 @@ final readonly class AnalysisResultCache
         $isReadonly         = $node['isReadonly'] ?? null;
         $dependencies       = $node['dependencies'] ?? null;
         $implements         = $node['implements'] ?? null;
+        $interfaceExtends   = $node['interfaceExtends'] ?? [];
         $traits             = $node['traits'] ?? [];
         $rawMethods         = $node['methods'] ?? null;
         $rawConstants       = $node['constants'] ?? null;
@@ -385,6 +387,7 @@ final readonly class AnalysisResultCache
             || ! is_bool($isReadonly)
             || ! $this->isStringArray($dependencies)
             || ! $this->isStringArray($implements)
+            || ! $this->isStringArray($interfaceExtends)
             || ! $this->isStringArray($traits)
             || ! is_array($rawMethods)
             || ! is_array($rawConstants)
@@ -446,27 +449,28 @@ final readonly class AnalysisResultCache
         }
 
         return new ClassNode(
-            className:     $className,
-            file:          $file,
-            line:          $line,
-            layer:         $layer,
-            extends:       $extends,
-            isAbstract:    $isAbstract,
-            isFinal:       $isFinal,
-            isInterface:   $isInterface,
-            isReadonly:    $isReadonly,
-            isTrait:       $isTrait,
-            dependencies:  array_values($dependencies),
-            implements:    array_values($implements),
-            traits:        array_values($traits),
-            methods:       $methods,
-            constants:     $constants,
-            properties:    $properties,
+            className:          $className,
+            file:               $file,
+            line:               $line,
+            layer:              $layer,
+            extends:            $extends,
+            isAbstract:         $isAbstract,
+            isFinal:            $isFinal,
+            isInterface:        $isInterface,
+            isReadonly:         $isReadonly,
+            isTrait:            $isTrait,
+            dependencies:       array_values($dependencies),
+            implements:         array_values($implements),
+            traits:             array_values($traits),
+            methods:            $methods,
+            constants:          $constants,
+            properties:         $properties,
             functionCalls:      array_values($functionCalls),
             superglobals:       array_values($superglobals),
             languageConstructs: array_values($languageConstructs),
             layers:             array_values($layers),
-            isEnum:        $isEnum,
+            isEnum:             $isEnum,
+            interfaceExtends:   array_values($interfaceExtends),
         );
     }
 

--- a/src/Cache/AnalysisResultCache.php
+++ b/src/Cache/AnalysisResultCache.php
@@ -330,6 +330,8 @@ final readonly class AnalysisResultCache
             'dependencies'       => $classNode->dependencies,
             'implements'         => array_values($classNode->implements),
             'interfaceExtends'   => array_values($classNode->interfaceExtends),
+            'parentClasses'      => $classNode->parentClasses,
+            'parentInterfaces'   => $classNode->parentInterfaces,
             'traits'             => array_values($classNode->traits),
             'methods'            => array_map($this->methodNodeToArray(...), $classNode->methods),
             'constants'          => array_map($this->constantNodeToArray(...), $classNode->constants),
@@ -364,6 +366,8 @@ final readonly class AnalysisResultCache
         $dependencies       = $node['dependencies'] ?? null;
         $implements         = $node['implements'] ?? null;
         $interfaceExtends   = $node['interfaceExtends'] ?? [];
+        $parentClasses      = $node['parentClasses'] ?? [];
+        $parentInterfaces   = $node['parentInterfaces'] ?? [];
         $traits             = $node['traits'] ?? [];
         $rawMethods         = $node['methods'] ?? null;
         $rawConstants       = $node['constants'] ?? null;
@@ -388,6 +392,8 @@ final readonly class AnalysisResultCache
             || ! $this->isStringArray($dependencies)
             || ! $this->isStringArray($implements)
             || ! $this->isStringArray($interfaceExtends)
+            || ! $this->isStringArray($parentClasses)
+            || ! $this->isStringArray($parentInterfaces)
             || ! $this->isStringArray($traits)
             || ! is_array($rawMethods)
             || ! is_array($rawConstants)
@@ -471,6 +477,8 @@ final readonly class AnalysisResultCache
             layers:             array_values($layers),
             isEnum:             $isEnum,
             interfaceExtends:   array_values($interfaceExtends),
+            parentClasses:      array_values($parentClasses),
+            parentInterfaces:   array_values($parentInterfaces),
         );
     }
 

--- a/src/Rule/Rules/Class_/ClassImplementingInterfaceMustHaveSuffixRule.php
+++ b/src/Rule/Rules/Class_/ClassImplementingInterfaceMustHaveSuffixRule.php
@@ -21,16 +21,9 @@ final readonly class ClassImplementingInterfaceMustHaveSuffixRule implements Rul
 
     public function appliesTo(ClassNode $classNode): bool
     {
-        if (! $classNode->isInLayer($this->layer)) {
-            return false;
-        }
-
-        if ($classNode->isClass()) {
-            return $classNode->implementsInterface($this->interface);
-        }
-
-        return $classNode->isInterface
-            && $classNode->extendsInterface($this->interface);
+        return $classNode->isClass()
+            && $classNode->isInLayer($this->layer)
+            && $classNode->implementsInterface($this->interface);
     }
 
     public function evaluate(ClassNode $classNode): ?RuleViolation
@@ -39,15 +32,10 @@ final readonly class ClassImplementingInterfaceMustHaveSuffixRule implements Rul
             return null;
         }
 
-        $declaration = $classNode->isInterface ? 'Interface' : 'Class';
-        $relation    = $classNode->isInterface ? 'extending' : 'implementing';
-
         return new RuleViolation(
             message:   sprintf(
-                '%s [%s] %s interface [%s] must have suffix [%s]',
-                $declaration,
+                'Class [%s] implementing interface [%s] must have suffix [%s]',
                 $classNode->className,
-                $relation,
                 $this->interface,
                 $this->suffix
             ),

--- a/src/Rule/Rules/Class_/ClassImplementingInterfaceMustHaveSuffixRule.php
+++ b/src/Rule/Rules/Class_/ClassImplementingInterfaceMustHaveSuffixRule.php
@@ -21,9 +21,16 @@ final readonly class ClassImplementingInterfaceMustHaveSuffixRule implements Rul
 
     public function appliesTo(ClassNode $classNode): bool
     {
-        return $classNode->isClass()
-            && $classNode->isInLayer($this->layer)
-            && $classNode->implementsInterface($this->interface);
+        if (! $classNode->isInLayer($this->layer)) {
+            return false;
+        }
+
+        if ($classNode->isClass()) {
+            return $classNode->implementsInterface($this->interface);
+        }
+
+        return $classNode->isInterface
+            && $classNode->extendsInterface($this->interface);
     }
 
     public function evaluate(ClassNode $classNode): ?RuleViolation
@@ -32,10 +39,15 @@ final readonly class ClassImplementingInterfaceMustHaveSuffixRule implements Rul
             return null;
         }
 
+        $declaration = $classNode->isInterface ? 'Interface' : 'Class';
+        $relation    = $classNode->isInterface ? 'extending' : 'implementing';
+
         return new RuleViolation(
             message:   sprintf(
-                'Class [%s] implementing interface [%s] must have suffix [%s]',
+                '%s [%s] %s interface [%s] must have suffix [%s]',
+                $declaration,
                 $classNode->className,
+                $relation,
                 $this->interface,
                 $this->suffix
             ),

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -1401,6 +1401,37 @@ final class AnalyserTest extends TestCase
         $this->assertSame(['App\\HTTP\\First', 'App\\HTTP\\Second'], $classes);
     }
 
+    public function testAnalyserStopsResolvingCyclicInterfaceParents(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/Contracts/First.php'  => <<<'PHP'
+                <?php
+
+                namespace App\Contracts;
+
+                interface First extends Second
+                {
+                }
+                PHP,
+            'src/Contracts/Second.php' => <<<'PHP'
+                <?php
+
+                namespace App\Contracts;
+
+                interface Second extends First
+                {
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Source', 'src/');
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
+
+        $this->assertFalse($ruleViolationCollection->hasViolations());
+    }
+
     public function testAnalyserRulesetAllowsSameLayerDependencies(): void
     {
         $basePath = $this->makeTempProject([

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -377,6 +377,54 @@ final class AnalyserTest extends TestCase
         $this->assertSame('App\Auth', $violations[0]->className);
     }
 
+    public function testPsr15PresetReportsClassExtendingCustomMiddlewareImplementationWithoutMiddlewareSuffix(): void
+    {
+        $basePath = $this->makeTempProject([
+            'app/AuthMiddleware.php'     => <<<'PHP'
+                <?php
+
+                namespace App;
+
+                interface AuthMiddleware extends \Psr\Http\Server\MiddlewareInterface
+                {
+                }
+                PHP,
+            'app/BaseAuthMiddleware.php' => <<<'PHP'
+                <?php
+
+                namespace App;
+
+                class BaseAuthMiddleware implements AuthMiddleware
+                {
+                    public function process(
+                        \Psr\Http\Message\ServerRequestInterface $request,
+                        \Psr\Http\Server\RequestHandlerInterface $handler
+                    ): \Psr\Http\Message\ResponseInterface {
+                        return $handler->handle($request);
+                    }
+                }
+                PHP,
+            'app/Auth.php'               => <<<'PHP'
+                <?php
+
+                namespace App;
+
+                final class Auth extends BaseAuthMiddleware
+                {
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->withPreset(Preset::PSR15(sourcePaths: ['app/']));
+
+        $violations = (new Analyser($basePath))->analyse($architecture)
+            ->forRule(Psr15Preset::MIDDLEWARE_INTERFACE_IMPLEMENTATION_MUST_HAVE_MIDDLEWARE_SUFFIX);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('App\\Auth', $violations[0]->className);
+    }
+
     public function testDddPresetResolvesConventionalLayersInsidePsr4SourceLayer(): void
     {
         $repositoryPath = 'src/Infrastructure/Persistence/Album/SQLAlbumRepository.php';

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -1397,6 +1397,53 @@ final class AnalyserTest extends TestCase
         $this->assertStringContainsString('App\\Pager\\PagerInterface', $violations[0]->message);
     }
 
+    public function testAnalyserRulesetReportsDependenciesInheritedFromInterfaceExtends(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/HTTP/ResponseInterface.php'     => <<<'PHP'
+                <?php
+
+                namespace App\HTTP;
+
+                interface ResponseInterface extends \App\Shared\PagerAwareInterface
+                {
+                }
+                PHP,
+            'src/Shared/PagerAwareInterface.php' => <<<'PHP'
+                <?php
+
+                namespace App\Shared;
+
+                interface PagerAwareInterface
+                {
+                    public function setLink(\App\Pager\PagerInterface $pager): void;
+                }
+                PHP,
+            'src/Pager/PagerInterface.php'       => <<<'PHP'
+                <?php
+
+                namespace App\Pager;
+
+                interface PagerInterface
+                {
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layerPattern('HTTP', '/^App\\\\HTTP\\\\.*$/')
+            ->layerPattern('Shared', '/^App\\\\Shared\\\\.*$/')
+            ->layerPattern('Pager', '/^App\\\\Pager\\\\.*$/')
+            ->ruleset(['HTTP' => ['Shared']]);
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['src/']);
+        $violations              = $ruleViolationCollection->forRule('ruleset.HTTP');
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('App\\HTTP\\ResponseInterface', $violations[0]->className);
+        $this->assertStringContainsString('App\\Pager\\PagerInterface', $violations[0]->message);
+    }
+
     public function testAnalyserRulesetStopsResolvingCyclicInheritanceDependencies(): void
     {
         $basePath = $this->makeTempProject([

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -9,6 +9,7 @@ use Boundwize\StructArmed\Analyser\AnalyserOptions;
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
 use Boundwize\StructArmed\Preset\Preset;
+use Boundwize\StructArmed\Preset\Presets\Psr15Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr1Preset;
 use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
 use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
@@ -309,6 +310,32 @@ final class AnalyserTest extends TestCase
         $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
 
         $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
+    }
+
+    public function testPsr15PresetAcceptsInterfaceExtendingMiddlewareInterfaceWithMiddlewareSuffix(): void
+    {
+        $basePath = $this->makeTempProject([
+            'app/AuthMiddleware.php' => <<<'PHP'
+                <?php
+
+                namespace App;
+
+                interface AuthMiddleware extends \Psr\Http\Server\MiddlewareInterface
+                {
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->withPreset(Preset::PSR15(sourcePaths: ['app/']));
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
+        $ruleKey                 = Psr15Preset::MIDDLEWARE_INTERFACE_IMPLEMENTATION_MUST_HAVE_MIDDLEWARE_SUFFIX;
+
+        $this->assertCount(
+            0,
+            $ruleViolationCollection->forRule($ruleKey)
+        );
     }
 
     public function testDddPresetResolvesConventionalLayersInsidePsr4SourceLayer(): void
@@ -1245,6 +1272,42 @@ final class AnalyserTest extends TestCase
 
         $this->assertCount(2, $violations);
         $this->assertSame(['App\\HTTP\\Response', 'App\\HTTP\\ResponseTrait'], $classes);
+    }
+
+    public function testAnalyserRulesetReportsInterfaceExtendsDependencyViolations(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/HTTP/ResponseInterface.php' => <<<'PHP'
+                <?php
+
+                namespace App\HTTP;
+
+                interface ResponseInterface extends \App\Pager\PagerInterface
+                {
+                }
+                PHP,
+            'src/Pager/PagerInterface.php'   => <<<'PHP'
+                <?php
+
+                namespace App\Pager;
+
+                interface PagerInterface
+                {
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layerPattern('HTTP', '/^App\\\\HTTP\\\\.*$/')
+            ->layerPattern('Pager', '/^App\\\\Pager\\\\.*$/')
+            ->ruleset(['HTTP' => []]);
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['src/']);
+        $violations              = $ruleViolationCollection->forRule('ruleset.HTTP');
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('App\\HTTP\\ResponseInterface', $violations[0]->className);
+        $this->assertStringContainsString('App\\Pager\\PagerInterface', $violations[0]->message);
     }
 
     public function testAnalyserRulesetStopsResolvingCyclicInheritanceDependencies(): void

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -338,6 +338,45 @@ final class AnalyserTest extends TestCase
         );
     }
 
+    public function testPsr15PresetReportsClassImplementingCustomMiddlewareInterfaceWithoutMiddlewareSuffix(): void
+    {
+        $basePath = $this->makeTempProject([
+            'app/AuthMiddleware.php' => <<<'PHP'
+                <?php
+
+                namespace App;
+
+                interface AuthMiddleware extends \Psr\Http\Server\MiddlewareInterface
+                {
+                }
+                PHP,
+            'app/Auth.php'           => <<<'PHP'
+                <?php
+
+                namespace App;
+
+                final class Auth implements AuthMiddleware
+                {
+                    public function process(
+                        \Psr\Http\Message\ServerRequestInterface $request,
+                        \Psr\Http\Server\RequestHandlerInterface $handler
+                    ): \Psr\Http\Message\ResponseInterface {
+                        return $handler->handle($request);
+                    }
+                }
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->withPreset(Preset::PSR15(sourcePaths: ['app/']));
+
+        $violations = (new Analyser($basePath))->analyse($architecture)
+            ->forRule(Psr15Preset::MIDDLEWARE_INTERFACE_IMPLEMENTATION_MUST_HAVE_MIDDLEWARE_SUFFIX);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('App\Auth', $violations[0]->className);
+    }
+
     public function testDddPresetResolvesConventionalLayersInsidePsr4SourceLayer(): void
     {
         $repositoryPath = 'src/Infrastructure/Persistence/Album/SQLAlbumRepository.php';

--- a/tests/Analyser/ClassCollectorTest.php
+++ b/tests/Analyser/ClassCollectorTest.php
@@ -71,6 +71,14 @@ final class ClassCollectorTest extends TestCase
         $this->assertTrue($classNode->isInterface);
     }
 
+    public function testCollectsInterfaceExtends(): void
+    {
+        $classNode = $this->collect('<?php interface FooInterface extends FirstInterface, SecondInterface {}');
+
+        $this->assertTrue($classNode->isInterface);
+        $this->assertSame(['FirstInterface', 'SecondInterface'], $classNode->interfaceExtends);
+    }
+
     public function testCollectsTrait(): void
     {
         $classNode = $this->collect('<?php trait FooTrait {}');

--- a/tests/Analyser/ClassNodeTest.php
+++ b/tests/Analyser/ClassNodeTest.php
@@ -102,11 +102,13 @@ final class ClassNodeTest extends TestCase
             functionCalls:      ['var_dump'],
             superglobals:       ['$_SERVER'],
             languageConstructs: ['exit'],
+            interfaceExtends:   ['App\\Contracts\\BaseOrderService'],
         );
 
         $this->assertTrue($classNode->dependsOnNamespace('App\\Infrastructure'));
         $this->assertFalse($classNode->dependsOnNamespace('App\\Application'));
         $this->assertTrue($classNode->implementsInterface('App\\Contracts\\OrderService'));
+        $this->assertTrue($classNode->extendsInterface('App\\Contracts\\BaseOrderService'));
         $this->assertTrue($classNode->callsFunction('var_dump'));
         $this->assertTrue($classNode->accessesSuperglobals());
         $this->assertTrue($classNode->usesLanguageConstruct('exit'));

--- a/tests/Analyser/ClassNodeTest.php
+++ b/tests/Analyser/ClassNodeTest.php
@@ -120,6 +120,29 @@ final class ClassNodeTest extends TestCase
         $this->assertFalse($classNode->usesLanguageConstruct('eval'));
     }
 
+    public function testSetRecursiveParents(): void
+    {
+        $classNode = new ClassNode(
+            className:   'App\\Domain\\OrderService',
+            file:        '/src/OrderService.php',
+            line:        5,
+            layer:       'Domain',
+            extends:     null,
+            isAbstract:  false,
+            isFinal:     false,
+            isInterface: false,
+            isReadonly:  false,
+        );
+
+        $classNode->setRecursiveParents(
+            ['App\\Support\\BaseOrderService'],
+            ['App\\Contracts\\OrderService'],
+        );
+
+        $this->assertSame(['App\\Support\\BaseOrderService'], $classNode->parentClasses);
+        $this->assertSame(['App\\Contracts\\OrderService'], $classNode->parentInterfaces);
+    }
+
     public function testDependsOnMatchesExistingClassesExactly(): void
     {
         $classNode = new ClassNode(

--- a/tests/Analyser/ClassNodeTest.php
+++ b/tests/Analyser/ClassNodeTest.php
@@ -103,12 +103,17 @@ final class ClassNodeTest extends TestCase
             superglobals:       ['$_SERVER'],
             languageConstructs: ['exit'],
             interfaceExtends:   ['App\\Contracts\\BaseOrderService'],
+            parentClasses:      ['App\\Support\\BaseOrderService'],
+            parentInterfaces:   ['App\\Contracts\\RootOrderService'],
         );
 
         $this->assertTrue($classNode->dependsOnNamespace('App\\Infrastructure'));
         $this->assertFalse($classNode->dependsOnNamespace('App\\Application'));
         $this->assertTrue($classNode->implementsInterface('App\\Contracts\\OrderService'));
+        $this->assertTrue($classNode->implementsInterface('App\\Contracts\\RootOrderService'));
+        $this->assertTrue($classNode->extendsClass('App\\Support\\BaseOrderService'));
         $this->assertTrue($classNode->extendsInterface('App\\Contracts\\BaseOrderService'));
+        $this->assertTrue($classNode->extendsInterface('App\\Contracts\\RootOrderService'));
         $this->assertTrue($classNode->callsFunction('var_dump'));
         $this->assertTrue($classNode->accessesSuperglobals());
         $this->assertTrue($classNode->usesLanguageConstruct('exit'));

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -648,6 +648,100 @@ final class AnalysisResultCacheTest extends TestCase
         }
     }
 
+    public function testClassNodesPreserveInterfaceExtends(): void
+    {
+        $cacheDirectory      = $this->createTempDirectory();
+        $sourceFile          = $cacheDirectory . '/Middleware.php';
+        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+
+        file_put_contents($sourceFile, '<?php interface Middleware extends BaseMiddleware {}');
+
+        $classNodes = [
+            new ClassNode(
+                className:        'App\Middleware',
+                file:             $sourceFile,
+                line:             1,
+                layer:            'Source',
+                extends:          null,
+                isAbstract:       false,
+                isFinal:          false,
+                isInterface:      true,
+                isReadonly:       false,
+                interfaceExtends: ['App\BaseMiddleware'],
+            ),
+        ];
+
+        try {
+            $analysisResultCache->storeClassNodes($sourceFile, 'config', $classNodes);
+            $loaded = $analysisResultCache->loadClassNodes($sourceFile, 'config');
+
+            $this->assertIsArray($loaded);
+            $this->assertSame(['App\BaseMiddleware'], $loaded[0]->interfaceExtends);
+            $this->assertEquals($classNodes, $loaded);
+        } finally {
+            if (file_exists($sourceFile)) {
+                unlink($sourceFile);
+            }
+
+            $this->removeTempDirectory($cacheDirectory);
+        }
+    }
+
+    public function testClassNodesLoadOldCachePayloadWithoutInterfaceExtends(): void
+    {
+        $cacheDirectory      = $this->createTempDirectory();
+        $sourceFile          = $cacheDirectory . '/Foo.php';
+        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+
+        file_put_contents($sourceFile, '<?php class Foo {}');
+
+        try {
+            $this->writeCachePayload($cacheDirectory, [
+                'metadata' => [
+                    'namespace' => 'config',
+                    'file'      => $sourceFile,
+                    'hash'      => hash('xxh128', (string) file_get_contents($sourceFile)),
+                ],
+                'nodes'    => [
+                    [
+                        'className'          => Foo::class,
+                        'file'               => $sourceFile,
+                        'line'               => 1,
+                        'layer'              => 'Source',
+                        'extends'            => null,
+                        'isAbstract'         => false,
+                        'isFinal'            => true,
+                        'isInterface'        => false,
+                        'isTrait'            => false,
+                        'isEnum'             => false,
+                        'isReadonly'         => false,
+                        'dependencies'       => [],
+                        'implements'         => [],
+                        'traits'             => [],
+                        'methods'            => [],
+                        'constants'          => [],
+                        'properties'         => [],
+                        'functionCalls'      => [],
+                        'superglobals'       => [],
+                        'languageConstructs' => [],
+                        'layers'             => [],
+                    ],
+                ],
+            ], 'class-nodes-' . hash('xxh128', "config\0" . $sourceFile) . '.json');
+
+            $loaded = $analysisResultCache->loadClassNodes($sourceFile, 'config');
+
+            $this->assertIsArray($loaded);
+            $this->assertSame([], $loaded[0]->interfaceExtends);
+        } finally {
+            if (file_exists($sourceFile)) {
+                unlink($sourceFile);
+            }
+
+            $this->removeTempDirectory($cacheDirectory);
+        }
+    }
+
     public function testClassNodesPreserveMethodExplicitVisibility(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
@@ -978,6 +1072,36 @@ final class AnalysisResultCacheTest extends TestCase
                         'functionCalls' => [],
                         'superglobals'  => [],
                         'layers'        => [],
+                    ],
+                ],
+            ],
+        ];
+        yield 'node has invalid interfaceExtends field' => [
+            [
+                'nodes' => [
+                    [
+                        'className'          => Foo::class,
+                        'file'               => __FILE__,
+                        'line'               => 1,
+                        'layer'              => null,
+                        'extends'            => null,
+                        'isAbstract'         => false,
+                        'isFinal'            => true,
+                        'isInterface'        => false,
+                        'isTrait'            => false,
+                        'isEnum'             => false,
+                        'isReadonly'         => false,
+                        'dependencies'       => [],
+                        'implements'         => [],
+                        'interfaceExtends'   => [10],
+                        'traits'             => [],
+                        'constants'          => [],
+                        'properties'         => [],
+                        'methods'            => [],
+                        'functionCalls'      => [],
+                        'superglobals'       => [],
+                        'languageConstructs' => [],
+                        'layers'             => [],
                     ],
                 ],
             ],

--- a/tests/Rule/Class_/ClassImplementingInterfaceMustHaveSuffixRuleTest.php
+++ b/tests/Rule/Class_/ClassImplementingInterfaceMustHaveSuffixRuleTest.php
@@ -48,44 +48,6 @@ final class ClassImplementingInterfaceMustHaveSuffixRuleTest extends TestCase
         $this->assertStringContainsString('Middleware', $violation->message);
     }
 
-    public function testPassesWhenInterfaceExtendingInterfaceHasSuffix(): void
-    {
-        $classImplementingInterfaceMustHaveSuffixRule = new ClassImplementingInterfaceMustHaveSuffixRule(
-            layer: 'Source',
-            interface: self::MIDDLEWARE_INTERFACE,
-            suffix: 'Middleware'
-        );
-
-        $violation = $classImplementingInterfaceMustHaveSuffixRule->evaluate($this->makeNode(
-            className:        'App\\Http\\AuthMiddleware',
-            implements:       [],
-            isInterface:      true,
-            interfaceExtends: [self::MIDDLEWARE_INTERFACE]
-        ));
-
-        $this->assertNotInstanceOf(RuleViolation::class, $violation);
-    }
-
-    public function testViolatesWhenInterfaceExtendingInterfaceIsMissingSuffix(): void
-    {
-        $classImplementingInterfaceMustHaveSuffixRule = new ClassImplementingInterfaceMustHaveSuffixRule(
-            layer: 'Source',
-            interface: self::MIDDLEWARE_INTERFACE,
-            suffix: 'Middleware'
-        );
-
-        $violation = $classImplementingInterfaceMustHaveSuffixRule->evaluate($this->makeNode(
-            className:        'App\\Http\\Auth',
-            implements:       [],
-            isInterface:      true,
-            interfaceExtends: [self::MIDDLEWARE_INTERFACE]
-        ));
-
-        $this->assertInstanceOf(RuleViolation::class, $violation);
-        $this->assertStringContainsString('Interface', $violation->message);
-        $this->assertStringContainsString('extending interface', $violation->message);
-    }
-
     public function testAppliesOnlyToClassesInLayerImplementingInterface(): void
     {
         $classImplementingInterfaceMustHaveSuffixRule = new ClassImplementingInterfaceMustHaveSuffixRule(
@@ -112,7 +74,7 @@ final class ClassImplementingInterfaceMustHaveSuffixRuleTest extends TestCase
             implements: [self::MIDDLEWARE_INTERFACE],
             isInterface: true
         )));
-        $this->assertTrue($classImplementingInterfaceMustHaveSuffixRule->appliesTo($this->makeNode(
+        $this->assertFalse($classImplementingInterfaceMustHaveSuffixRule->appliesTo($this->makeNode(
             className:        'App\\Http\\AuthMiddleware',
             implements:       [],
             isInterface:      true,

--- a/tests/Rule/Class_/ClassImplementingInterfaceMustHaveSuffixRuleTest.php
+++ b/tests/Rule/Class_/ClassImplementingInterfaceMustHaveSuffixRuleTest.php
@@ -48,6 +48,44 @@ final class ClassImplementingInterfaceMustHaveSuffixRuleTest extends TestCase
         $this->assertStringContainsString('Middleware', $violation->message);
     }
 
+    public function testPassesWhenInterfaceExtendingInterfaceHasSuffix(): void
+    {
+        $classImplementingInterfaceMustHaveSuffixRule = new ClassImplementingInterfaceMustHaveSuffixRule(
+            layer: 'Source',
+            interface: self::MIDDLEWARE_INTERFACE,
+            suffix: 'Middleware'
+        );
+
+        $violation = $classImplementingInterfaceMustHaveSuffixRule->evaluate($this->makeNode(
+            className:        'App\\Http\\AuthMiddleware',
+            implements:       [],
+            isInterface:      true,
+            interfaceExtends: [self::MIDDLEWARE_INTERFACE]
+        ));
+
+        $this->assertNotInstanceOf(RuleViolation::class, $violation);
+    }
+
+    public function testViolatesWhenInterfaceExtendingInterfaceIsMissingSuffix(): void
+    {
+        $classImplementingInterfaceMustHaveSuffixRule = new ClassImplementingInterfaceMustHaveSuffixRule(
+            layer: 'Source',
+            interface: self::MIDDLEWARE_INTERFACE,
+            suffix: 'Middleware'
+        );
+
+        $violation = $classImplementingInterfaceMustHaveSuffixRule->evaluate($this->makeNode(
+            className:        'App\\Http\\Auth',
+            implements:       [],
+            isInterface:      true,
+            interfaceExtends: [self::MIDDLEWARE_INTERFACE]
+        ));
+
+        $this->assertInstanceOf(RuleViolation::class, $violation);
+        $this->assertStringContainsString('Interface', $violation->message);
+        $this->assertStringContainsString('extending interface', $violation->message);
+    }
+
     public function testAppliesOnlyToClassesInLayerImplementingInterface(): void
     {
         $classImplementingInterfaceMustHaveSuffixRule = new ClassImplementingInterfaceMustHaveSuffixRule(
@@ -74,28 +112,37 @@ final class ClassImplementingInterfaceMustHaveSuffixRuleTest extends TestCase
             implements: [self::MIDDLEWARE_INTERFACE],
             isInterface: true
         )));
+        $this->assertTrue($classImplementingInterfaceMustHaveSuffixRule->appliesTo($this->makeNode(
+            className:        'App\\Http\\AuthMiddleware',
+            implements:       [],
+            isInterface:      true,
+            interfaceExtends: [self::MIDDLEWARE_INTERFACE],
+        )));
     }
 
     /**
      * @param string[] $implements
+     * @param string[] $interfaceExtends
      */
     private function makeNode(
         string $className,
         array $implements,
         string $layer = 'Source',
         bool $isInterface = false,
+        array $interfaceExtends = [],
     ): ClassNode {
         return new ClassNode(
-            className:   $className,
-            file:        '/fake.php',
-            line:        1,
-            layer:       $layer,
-            extends:     null,
-            isAbstract:  false,
-            isFinal:     false,
-            isInterface: $isInterface,
-            isReadonly:  false,
-            implements:  $implements,
+            className:        $className,
+            file:             '/fake.php',
+            line:             1,
+            layer:            $layer,
+            extends:          null,
+            isAbstract:       false,
+            isFinal:          false,
+            isInterface:      $isInterface,
+            isReadonly:       false,
+            implements:       $implements,
+            interfaceExtends: $interfaceExtends,
         );
     }
 }


### PR DESCRIPTION
Adds recursive inheritance awareness to `ClassNode` so rules can detect interface implemented through scanned parent chains.

For example, this now resolves correctly:

```php
class A extends B {}
class B extends C {}
class C implements \Psr\Http\Server\MiddlewareInterface {}
```

`A` is now treated as implementing `\Psr\Http\Server\MiddlewareInterface`.

The example usage is in `ClassImplementingInterfaceMustHaveSuffixRule`, which now applies to class extends another class extends another class that implements `\Psr\Http\Server\MiddlewareInterface`.

This keeps PSR-15 suffix checks compatible with custom middleware/request-handler before reach root `\Psr\Http\Server\MiddlewareInterface`.