### PR TITLE
feat: add ExtendedClassAwareRuleInterface to detect extended classes

### DIFF
--- a/docs/assets/no-violation.svg
+++ b/docs/assets/no-violation.svg
@@ -14,7 +14,7 @@
         <text x="0" y="0" class="text"><tspan class="prompt">➜  </tspan><tspan class="dir">prj-ddd </tspan><tspan class="cmd">vendor/bin/structarmed analyze</tspan></text>
 
         <!-- Line 3: Title and Version -->
-        <text x="0" y="35" class="text header">StructArmed <tspan class="version">0.14.20</tspan> — Architecture Enforcement</text>
+        <text x="0" y="35" class="text header">StructArmed <tspan class="version">0.15.0</tspan> — Architecture Enforcement</text>
 
         <!-- Line 4: Separator (Reduced length) -->
         <text x="0" y="49" class="text">===============================================</text>

--- a/docs/assets/structarmed-showoff.svg
+++ b/docs/assets/structarmed-showoff.svg
@@ -15,7 +15,7 @@
         <text x="0" y="0" class="text"><tspan class="prompt">➜  </tspan><tspan class="dir">prj-ddd </tspan><tspan class="cmd">vendor/bin/structarmed analyze</tspan></text>
 
         <!-- Line 3: Title and Version -->
-        <text x="0" y="35" class="text header">StructArmed <tspan class="version">0.14.20</tspan> — Architecture Enforcement</text>
+        <text x="0" y="35" class="text header">StructArmed <tspan class="version">0.15.0</tspan> — Architecture Enforcement</text>
 
         <!-- Line 4: Separator -->
         <text x="0" y="49" class="text">===============================================</text>

--- a/docs/available-rules.md
+++ b/docs/available-rules.md
@@ -80,7 +80,7 @@ Namespace: `Boundwize\StructArmed\Rule\Rules\Class_`.
 | `ClassNameMustNotHavePrefixRule` | `new ClassNameMustNotHavePrefixRule(layer: 'Model', prefix: 'Model')` | Classes in a layer do not use a forbidden prefix. |
 | `MaxDependencyCountRule` | `new MaxDependencyCountRule(layer: 'Controller', maxCount: 5)` | Constructor dependency count stays below the configured limit. |
 | `MayNotImplementInterfaceRule` | `new MayNotImplementInterfaceRule(layer: 'Domain', interface: JsonSerializable::class)` | Classes in a layer do not implement a forbidden interface. |
-| `MustBeFinalRule` | `new MustBeFinalRule(layer: 'Domain', classNamePattern: '/Entity$/')` | Matching classes in a layer are declared `final`. Supports `--fix`. |
+| `MustBeFinalRule` | `new MustBeFinalRule(layer: 'Domain', classNamePattern: '/Entity$/')` | Matching classes in a layer are declared `final`. Classes extended by another scanned class are skipped (making them `final` would break the child). Supports `--fix`. |
 | `MustBeInterfaceRule` | `new MustBeInterfaceRule(layer: 'Contract', classNamePattern: '/Interface$/')` | Matching declarations in a layer are interfaces. |
 | `MustDeclareConstantVisibilityRule` | `new MustDeclareConstantVisibilityRule(layer: 'Source')` | Class constants declare `public`, `protected`, or `private`. Supports `--fix`. |
 | `MustDeclareMethodVisibilityRule` | `new MustDeclareMethodVisibilityRule(layer: 'Source')` | Methods declare `public`, `protected`, or `private`. Supports `--fix`. |

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -674,7 +674,11 @@ final readonly class Analyser
         }
 
         foreach ($classNodes as $classNode) {
-            $classNode->setExtended(isset($extended[$classNode->className]));
+            // Only classes appear in parentClasses; traits, interfaces, and enums
+            // never do, so they are left with the default (not extended).
+            if (isset($extended[$classNode->className])) {
+                $classNode->setExtended(true);
+            }
         }
     }
 

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -12,6 +12,7 @@ use Boundwize\StructArmed\Composer\Psr4PathResolver;
 use Boundwize\StructArmed\LayerResolver\ChainLayerResolver;
 use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
 use Boundwize\StructArmed\Rule\ComposerJsonRuleInterface;
+use Boundwize\StructArmed\Rule\ExtendedClassAwareRuleInterface;
 use Boundwize\StructArmed\Rule\FileAnalysisRuleInterface;
 use Boundwize\StructArmed\Rule\FixableInterface;
 use Boundwize\StructArmed\Rule\LayerAwareRuleInterface;
@@ -140,6 +141,10 @@ final readonly class Analyser
         );
         $classNodes       = $extractionResult->classNodes;
         $classNodes       = $this->withRecursiveParents($classNodes);
+
+        if ($this->hasExtendedClassAwareRule($classRules)) {
+            $this->markExtendedClasses($classNodes);
+        }
 
         $fileAnalysisProvider = new FileAnalysisProvider($extractionResult->fileAnalyses);
 
@@ -644,6 +649,42 @@ final readonly class Analyser
         $cycleDetected = $cycleDetected || $hasCycle;
 
         return $resolvedDependencies;
+    }
+
+    /**
+     * @param array<string, RuleInterface> $classRules
+     */
+    private function hasExtendedClassAwareRule(array $classRules): bool
+    {
+        foreach ($classRules as $classRule) {
+            if ($classRule instanceof ExtendedClassAwareRuleInterface) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Flag every class that another scanned class extends, using the recursive
+     * parent chain resolved by {@see withRecursiveParents()}. A class name found
+     * among any node's parent classes is extended within the scanned paths.
+     *
+     * @param list<ClassNode> $classNodes
+     */
+    private function markExtendedClasses(array $classNodes): void
+    {
+        $extended = [];
+
+        foreach ($classNodes as $classNode) {
+            foreach ($classNode->parentClasses as $parentClass) {
+                $extended[$parentClass] = true;
+            }
+        }
+
+        foreach ($classNodes as $classNode) {
+            $classNode->setExtended(isset($extended[$classNode->className]));
+        }
     }
 
     /**

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -86,9 +86,10 @@ final readonly class Analyser
         $classRules       = $this->classRules($rules, $skippedRuleKeys);
         $ruleSkipMatchers = $this->ruleSkipMatchers($classRules, $globalSkipPaths, $ruleSkipPaths);
 
-        $projectRuleViolations = [];
-        $fileAnalysisRules     = [];
-        $layerAwareRules       = [];
+        $projectRuleViolations     = [];
+        $fileAnalysisRules         = [];
+        $layerAwareRules           = [];
+        $hasExtendedClassAwareRule = false;
 
         foreach ($rules as $key => $rule) {
             if (array_key_exists($key, $skippedRuleKeys)) {
@@ -97,6 +98,10 @@ final readonly class Analyser
 
             if ($rule instanceof LayerAwareRuleInterface) {
                 $layerAwareRules[] = $rule;
+            }
+
+            if ($rule instanceof ExtendedClassAwareRuleInterface) {
+                $hasExtendedClassAwareRule = true;
             }
 
             if (! $rule instanceof ProjectRuleInterface) {
@@ -142,7 +147,7 @@ final readonly class Analyser
         $classNodes       = $extractionResult->classNodes;
         $classNodes       = $this->withRecursiveParents($classNodes);
 
-        if ($this->hasExtendedClassAwareRule($classRules)) {
+        if ($hasExtendedClassAwareRule) {
             $this->markExtendedClasses($classNodes);
         }
 
@@ -649,20 +654,6 @@ final readonly class Analyser
         $cycleDetected = $cycleDetected || $hasCycle;
 
         return $resolvedDependencies;
-    }
-
-    /**
-     * @param array<string, RuleInterface> $classRules
-     */
-    private function hasExtendedClassAwareRule(array $classRules): bool
-    {
-        foreach ($classRules as $classRule) {
-            if ($classRule instanceof ExtendedClassAwareRuleInterface) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/src/Analyser/ClassNode.php
+++ b/src/Analyser/ClassNode.php
@@ -58,6 +58,7 @@ final class ClassNode
         public readonly array $interfaceExtends = [],
         public array $parentClasses = [],
         public array $parentInterfaces = [],
+        public bool $isExtended = false,
     ) {
         $this->layers = $layers ?: array_filter([$this->layer]);
     }
@@ -70,6 +71,15 @@ final class ClassNode
     {
         $this->parentClasses    = $parentClasses;
         $this->parentInterfaces = $parentInterfaces;
+    }
+
+    /**
+     * Whether another scanned class extends this class. Computed by the analyser
+     * for rules implementing ExtendedClassAwareRuleInterface; false otherwise.
+     */
+    public function setExtended(bool $isExtended): void
+    {
+        $this->isExtended = $isExtended;
     }
 
     public function shortName(): string

--- a/src/Rule/ExtendedClassAwareRuleInterface.php
+++ b/src/Rule/ExtendedClassAwareRuleInterface.php
@@ -13,6 +13,6 @@ namespace Boundwize\StructArmed\Rule;
  * Trade-off: only classes extended within the scanned paths are known. A class
  * extended solely by a consumer outside the scan is reported as if not extended.
  */
-interface ExtendedClassAwareRuleInterface
+interface ExtendedClassAwareRuleInterface extends RuleInterface
 {
 }

--- a/src/Rule/ExtendedClassAwareRuleInterface.php
+++ b/src/Rule/ExtendedClassAwareRuleInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Rule;
+
+/**
+ * Marker for rules whose evaluation depends on whether a class is extended by
+ * another scanned class. When at least one active rule implements this marker,
+ * the analyser flags each ClassNode's $isExtended (from its recursive parents)
+ * before rules are evaluated, so implementers can read $classNode->isExtended.
+ *
+ * Trade-off: only classes extended within the scanned paths are known. A class
+ * extended solely by a consumer outside the scan is reported as if not extended.
+ */
+interface ExtendedClassAwareRuleInterface
+{
+}

--- a/src/Rule/Rules/Class_/MustBeFinalRule.php
+++ b/src/Rule/Rules/Class_/MustBeFinalRule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Boundwize\StructArmed\Rule\Rules\Class_;
 
 use Boundwize\StructArmed\Analyser\ClassNode;
+use Boundwize\StructArmed\Rule\ExtendedClassAwareRuleInterface;
 use Boundwize\StructArmed\Rule\Fixer\PhpParser\AbstractPhpParserFixableRule;
 use Boundwize\StructArmed\Rule\Fixer\PhpParser\Class_\AddFinalClassVisitor;
 use Boundwize\StructArmed\Rule\RuleInterface;
@@ -12,7 +13,9 @@ use Boundwize\StructArmed\Rule\RuleViolation;
 
 use function sprintf;
 
-final readonly class MustBeFinalRule extends AbstractPhpParserFixableRule implements RuleInterface
+final readonly class MustBeFinalRule extends AbstractPhpParserFixableRule implements
+    RuleInterface,
+    ExtendedClassAwareRuleInterface
 {
     public function __construct(
         private string $layer,
@@ -40,6 +43,12 @@ final readonly class MustBeFinalRule extends AbstractPhpParserFixableRule implem
     public function evaluate(ClassNode $classNode): ?RuleViolation
     {
         if ($classNode->isFinal) {
+            return null;
+        }
+
+        // A class another scanned class extends cannot be made final; forcing it
+        // would break the child, so treat it as legitimately non-final.
+        if ($classNode->isExtended) {
             return null;
         }
 

--- a/src/Rule/Rules/Class_/MustBeFinalRule.php
+++ b/src/Rule/Rules/Class_/MustBeFinalRule.php
@@ -8,14 +8,11 @@ use Boundwize\StructArmed\Analyser\ClassNode;
 use Boundwize\StructArmed\Rule\ExtendedClassAwareRuleInterface;
 use Boundwize\StructArmed\Rule\Fixer\PhpParser\AbstractPhpParserFixableRule;
 use Boundwize\StructArmed\Rule\Fixer\PhpParser\Class_\AddFinalClassVisitor;
-use Boundwize\StructArmed\Rule\RuleInterface;
 use Boundwize\StructArmed\Rule\RuleViolation;
 
 use function sprintf;
 
-final readonly class MustBeFinalRule extends AbstractPhpParserFixableRule implements
-    RuleInterface,
-    ExtendedClassAwareRuleInterface
+final readonly class MustBeFinalRule extends AbstractPhpParserFixableRule implements ExtendedClassAwareRuleInterface
 {
     public function __construct(
         private string $layer,

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -95,6 +95,52 @@ final class AnalyserTest extends TestCase
         $this->assertCount(2, $ruleViolationCollection->forRule('source.must_be_final'));
     }
 
+    public function testMustBeFinalRuleDoesNotFlagClassExtendedByAnotherScannedClass(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/BaseHandler.php'    => '<?php namespace App; class BaseHandler {}',
+            'src/OrderHandler.php'   => '<?php namespace App; final class OrderHandler extends BaseHandler {}',
+            'src/PaymentHandler.php' => '<?php namespace App; class PaymentHandler {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Source', 'src/')
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        $violations = (new Analyser($basePath))
+            ->analyse($architecture, [], null, AnalyserOptions::sequential())
+            ->forRule('source.must_be_final');
+
+        // BaseHandler is extended (must stay non-final); PaymentHandler is the
+        // only genuinely non-final leaf class.
+        $this->assertCount(1, $violations);
+        $this->assertSame('App\PaymentHandler', $violations[0]->className);
+    }
+
+    public function testMustBeFinalRuleFlagsExtendedClassWhenChildIsOutsideScannedPaths(): void
+    {
+        $order = '<?php namespace Consumer; use App\BaseHandler;' . "\n"
+            . 'final class OrderHandler extends BaseHandler {}';
+
+        $basePath = $this->makeTempProject([
+            'src/BaseHandler.php'       => '<?php namespace App; class BaseHandler {}',
+            'consumer/OrderHandler.php' => $order,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Source', 'src/')
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        $violations = (new Analyser($basePath))
+            ->analyse($architecture, ['src/'], null, AnalyserOptions::sequential())
+            ->forRule('source.must_be_final');
+
+        // The extending class lives outside the scanned paths, so BaseHandler is
+        // reported as if not extended — a false positive on purpose.
+        $this->assertCount(1, $violations);
+        $this->assertSame('App\BaseHandler', $violations[0]->className);
+    }
+
     public function testAnalyserMarksFixableRuleViolations(): void
     {
         $basePath = $this->makeTempProject([

--- a/tests/Analyser/ClassNodeTest.php
+++ b/tests/Analyser/ClassNodeTest.php
@@ -182,6 +182,29 @@ final class ClassNodeTest extends TestCase
         $this->assertSame(['App\\Contracts\\OrderService'], $classNode->parentInterfaces);
     }
 
+    public function testSetExtendedTogglesIsExtendedFlag(): void
+    {
+        $classNode = new ClassNode(
+            className:   'App\\Domain\\OrderService',
+            file:        '/src/OrderService.php',
+            line:        5,
+            layer:       'Domain',
+            extends:     null,
+            isAbstract:  false,
+            isFinal:     false,
+            isInterface: false,
+            isReadonly:  false,
+        );
+
+        $this->assertFalse($classNode->isExtended);
+
+        $classNode->setExtended(true);
+        $this->assertTrue($classNode->isExtended);
+
+        $classNode->setExtended(false);
+        $this->assertFalse($classNode->isExtended);
+    }
+
     public function testDependsOnMatchesExistingClassesExactly(): void
     {
         $classNode = new ClassNode(

--- a/tests/Rule/Class_/MustBeFinalRuleTest.php
+++ b/tests/Rule/Class_/MustBeFinalRuleTest.php
@@ -6,6 +6,7 @@ namespace Boundwize\StructArmed\Tests\Rule\Class_;
 
 use Boundwize\StructArmed\Analyser\ClassNode;
 use Boundwize\StructArmed\Preset\Preset;
+use Boundwize\StructArmed\Rule\ExtendedClassAwareRuleInterface;
 use Boundwize\StructArmed\Rule\FixableInterface;
 use Boundwize\StructArmed\Rule\Fixer\PhpParser\Class_\AddFinalClassVisitor;
 use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
@@ -25,6 +26,7 @@ final class MustBeFinalRuleTest extends TestCase
         bool $isInterface = false,
         bool $isTrait = false,
         bool $isEnum = false,
+        bool $isExtended = false,
     ): ClassNode {
         return new ClassNode(
             className:  $className,
@@ -38,6 +40,7 @@ final class MustBeFinalRuleTest extends TestCase
             isReadonly: false,
             isTrait:    $isTrait,
             isEnum:     $isEnum,
+            isExtended: $isExtended,
         );
     }
 
@@ -58,6 +61,22 @@ final class MustBeFinalRuleTest extends TestCase
 
         $this->assertInstanceOf(RuleViolation::class, $violation);
         $this->assertStringContainsString('final', $violation->message);
+    }
+
+    public function testPassesWhenClassIsExtendedByAnotherClass(): void
+    {
+        $mustBeFinalRule = new MustBeFinalRule(layer: 'Domain');
+        $classNode       = $this->makeNode(isFinal: false, isExtended: true);
+
+        $this->assertNotInstanceOf(RuleViolation::class, $mustBeFinalRule->evaluate($classNode));
+    }
+
+    public function testIsExtendedClassAware(): void
+    {
+        $this->assertInstanceOf(
+            ExtendedClassAwareRuleInterface::class,
+            new MustBeFinalRule(layer: 'Domain')
+        );
     }
 
     public function testIsFixable(): void


### PR DESCRIPTION
This PR introduces `Boundwize\StructArmed\Rule\ExtendedClassAwareRuleInterface`.

A marker that lets a rule know whether the class it's evaluating is extended by another scanned class, and applies it to `Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule`.

Using interface in custom rule:

```php
use Boundwize\StructArmed\Analyser\ClassNode;
use Boundwize\StructArmed\Rule\ExtendedClassAwareRuleInterface;
use Boundwize\StructArmed\Rule\RuleViolation;

final readonly class MyRule implements ExtendedClassAwareRuleInterface
{
    public function appliesTo(ClassNode $classNode): bool
    {
        return $classNode->isClass();
    }

    public function evaluate(ClassNode $classNode): ?RuleViolation
    {
        // Skip classes that another scanned class extends.
        if ($classNode->isExtended) {
            return null;
        }

        // other check ...

        return new RuleViolation(
            ...
        );
    }
}
```
