### PR TITLE
fix: consistent canonicalize path returned by file finder

### DIFF
--- a/src/Rule/Rules/File/PhpFileFinder.php
+++ b/src/Rule/Rules/File/PhpFileFinder.php
@@ -73,7 +73,7 @@ final readonly class PhpFileFinder
 
         /** @var SplFileInfo $file */
         foreach ($append as $file) {
-            $files[] = $file->getPathname();
+            $files[] = Path::normalise($file->getPathname(), canonicalise: true);
         }
 
         // ensure nothing duplicated once more

--- a/tests/Rule/File/Psr1PhpTagsRuleTest.php
+++ b/tests/Rule/File/Psr1PhpTagsRuleTest.php
@@ -357,8 +357,8 @@ final class Psr1PhpTagsRuleTest extends TestCase
             $this->assertCount(1, $violations);
             $this->assertSame(37, $violations[0]->line);
             $this->assertStringStartsWith(
-                rtrim(str_replace('\\', '/', $analysisBasePath), '/') . '/',
-                str_replace('\\', '/', $violations[0]->file),
+                realpath($analysisBasePath),
+                realpath($violations[0]->file),
             );
         } finally {
             if (DIRECTORY_SEPARATOR !== '\\') {

--- a/tests/Rule/File/Psr1PhpTagsRuleTest.php
+++ b/tests/Rule/File/Psr1PhpTagsRuleTest.php
@@ -26,7 +26,6 @@ use function mkdir;
 use function random_bytes;
 use function realpath;
 use function rmdir;
-use function rtrim;
 use function str_replace;
 use function symlink;
 use function sys_get_temp_dir;

--- a/tests/Rule/File/Psr1PhpTagsRuleTest.php
+++ b/tests/Rule/File/Psr1PhpTagsRuleTest.php
@@ -355,9 +355,16 @@ final class Psr1PhpTagsRuleTest extends TestCase
 
             $this->assertCount(1, $violations);
             $this->assertSame(37, $violations[0]->line);
+
+            /** @var non-empty-string $realPathAnalysisBasePath */
+            $realPathAnalysisBasePath = realpath($analysisBasePath);
+
+            /** @var non-empty-string $realPathFile */
+            $realPathFile = realpath($violations[0]->file);
+
             $this->assertStringStartsWith(
-                (string) realpath($analysisBasePath),
-                (string) realpath($violations[0]->file),
+                $realPathAnalysisBasePath,
+                $realPathFile,
             );
         } finally {
             if (DIRECTORY_SEPARATOR !== '\\') {

--- a/tests/Rule/File/Psr1PhpTagsRuleTest.php
+++ b/tests/Rule/File/Psr1PhpTagsRuleTest.php
@@ -356,8 +356,8 @@ final class Psr1PhpTagsRuleTest extends TestCase
             $this->assertCount(1, $violations);
             $this->assertSame(37, $violations[0]->line);
             $this->assertStringStartsWith(
-                realpath($analysisBasePath),
-                realpath($violations[0]->file),
+                (string) realpath($analysisBasePath),
+                (string) realpath($violations[0]->file),
             );
         } finally {
             if (DIRECTORY_SEPARATOR !== '\\') {


### PR DESCRIPTION
make consistent with

https://github.com/boundwize/structarmed/blob/2ba72a1cf7203064d0f8a63af3d6a0834f1d716b/src/Analyser/Analyser.php#L1191

Should be refactored to use single service later when possible.