### PR TITLE
Refactor: extract shared SkipPathMatcher and PhpFileCollector services to deduplicate file finding and skip logic in Analyser and PhpFileFinder

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -9,6 +9,8 @@ use Boundwize\StructArmed\Analyser\Parallel\ParallelClassNodeExtractor;
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
 use Boundwize\StructArmed\Composer\Psr4PathResolver;
+use Boundwize\StructArmed\File\PhpFileCollector;
+use Boundwize\StructArmed\File\SkipPathMatcher;
 use Boundwize\StructArmed\LayerResolver\ChainLayerResolver;
 use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
 use Boundwize\StructArmed\Rule\ComposerJsonRuleInterface;
@@ -23,11 +25,6 @@ use Boundwize\StructArmed\Rule\RuleInterface;
 use Boundwize\StructArmed\Rule\RuleViolation;
 use Boundwize\StructArmed\Rule\RuleViolationCollection;
 use Boundwize\StructArmed\Util\Path;
-use FilesystemIterator;
-use RecursiveCallbackFilterIterator;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use SplFileInfo;
 
 use function array_fill_keys;
 use function array_filter;
@@ -38,14 +35,12 @@ use function array_merge;
 use function array_unique;
 use function array_values;
 use function count;
-use function fnmatch;
 use function getcwd;
 use function in_array;
 use function is_dir;
 use function is_file;
 use function sprintf;
 use function str_starts_with;
-use function strpbrk;
 use function substr;
 
 use const ARRAY_FILTER_USE_BOTH;
@@ -60,6 +55,7 @@ final readonly class Analyser
         string $basePath = '',
         private ?AnalysisResultCache $analysisResultCache = null,
         private string $classNodeCacheNamespace = '',
+        private PhpFileCollector $phpFileCollector = new PhpFileCollector(),
     ) {
         $this->basePath           = $basePath !== '' ? $basePath : (string) getcwd();
         $this->normalisedBasePath = Path::normalise($this->basePath, canonicalise: true);
@@ -190,7 +186,7 @@ final readonly class Analyser
         $ruleset                    = $this->expandRuleset($architecture->getRuleset());
         $classViolationSkips        = $architecture->getClassViolationSkips();
         $rulesetSkipPaths           = $this->mergedSkipPaths($globalSkipPaths, $architecture->getRulesetSkipPaths());
-        $rulesetSkipMatchers        = $this->compileSkipMatchers($rulesetSkipPaths);
+        $rulesetSkipPathMatcher     = SkipPathMatcher::compile($this->basePath, $rulesetSkipPaths);
         $rulesetViolationCollection = new RuleViolationCollection();
         $hasRuleset                 = $ruleset !== [];
         $scanScopeLayerMap          = $hasRuleset ? $this->scanScopeLayerMap($architecture) : [];
@@ -217,7 +213,7 @@ final readonly class Analyser
 
         foreach ($classNodes as $classNode) {
             foreach ($classRules as $key => $rule) {
-                if ($this->isSkipped($classNode->file, $ruleSkipMatchers[$key])) {
+                if ($ruleSkipMatchers[$key]->isSkipped($classNode->file)) {
                     continue;
                 }
 
@@ -263,7 +259,7 @@ final readonly class Analyser
                 continue;
             }
 
-            if ($rulesetSkipPaths !== [] && $this->isSkipped($classNode->file, $rulesetSkipMatchers)) {
+            if ($rulesetSkipPaths !== [] && $rulesetSkipPathMatcher->isSkipped($classNode->file)) {
                 continue;
             }
 
@@ -466,14 +462,15 @@ final readonly class Analyser
      * @param array<string, RuleInterface> $classRules
      * @param list<string>                 $globalSkipPaths
      * @param array<string, list<string>>  $ruleSkipPaths
-     * @return array<string, array{paths: list<string>, patterns: list<string>}>
+     * @return array<string, SkipPathMatcher>
      */
     private function ruleSkipMatchers(array $classRules, array $globalSkipPaths, array $ruleSkipPaths): array
     {
         $ruleSkipMatchers = [];
 
         foreach (array_keys($classRules) as $key) {
-            $ruleSkipMatchers[$key] = $this->compileSkipMatchers(
+            $ruleSkipMatchers[$key] = SkipPathMatcher::compile(
+                $this->basePath,
                 $this->mergedSkipPaths($globalSkipPaths, $ruleSkipPaths[$key] ?? [])
             );
         }
@@ -967,12 +964,12 @@ final readonly class Analyser
             return $violations;
         }
 
-        $skipMatchers = $this->compileSkipMatchers($skipPaths);
+        $skipPathMatcher = SkipPathMatcher::compile($this->basePath, $skipPaths);
 
         return array_values(array_filter(
             $violations,
-            fn(RuleViolation $ruleViolation): bool => $ruleViolation->file === ''
-                || ! $this->isSkipped($ruleViolation->file, $skipMatchers),
+            static fn(RuleViolation $ruleViolation): bool => $ruleViolation->file === ''
+                || ! $skipPathMatcher->isSkipped($ruleViolation->file),
         ));
     }
 
@@ -983,11 +980,10 @@ final readonly class Analyser
      */
     public function filesForAnalysis(Architecture $architecture, array $scanPaths = [], ?array $layers = null): array
     {
-        $layers     ??= $this->resolveLayers($architecture);
-        $files        = [];
-        $skipPaths    = $architecture->getSkipPaths();
-        $skipMatchers = $this->compileSkipMatchers($skipPaths);
-        $scanPaths    = $this->scanPaths($layers, $scanPaths);
+        $layers        ??= $this->resolveLayers($architecture);
+        $files           = [];
+        $skipPathMatcher = SkipPathMatcher::compile($this->basePath, $architecture->getSkipPaths());
+        $scanPaths       = $this->scanPaths($layers, $scanPaths);
 
         if ($this->shouldAnalyseComposerJson($architecture)) {
             $scanPaths[] = 'composer.json';
@@ -1002,7 +998,7 @@ final readonly class Analyser
             if (is_file($fullPath)) {
                 if (
                     Path::isAnalysableFile($fullPath, $this->basePath)
-                    && ! $this->isSkipped($fullPath, $skipMatchers)
+                    && ! $skipPathMatcher->isSkipped($fullPath)
                 ) {
                     $files[] = $fullPath;
                 }
@@ -1014,11 +1010,11 @@ final readonly class Analyser
                 continue;
             }
 
-            if ($this->isSkipped($fullPath, $skipMatchers)) {
+            if ($skipPathMatcher->isSkipped($fullPath)) {
                 continue;
             }
 
-            foreach ($this->phpFiles($fullPath, $skipMatchers) as $file) {
+            foreach ($this->phpFileCollector->collect($fullPath, $skipPathMatcher) as $file) {
                 $files[] = $file;
             }
         }
@@ -1064,9 +1060,8 @@ final readonly class Analyser
             return false;
         }
 
-        return $this->isSkipped(
-            Path::resolve('composer.json', $this->normalisedBasePath),
-            $this->compileSkipMatchers($skipPaths)
+        return SkipPathMatcher::compile($this->basePath, $skipPaths)->isSkipped(
+            Path::resolve('composer.json', $this->normalisedBasePath)
         );
     }
 
@@ -1107,90 +1102,5 @@ final readonly class Analyser
         }
 
         return $paths;
-    }
-
-    /**
-     * @param list<string> $skipPaths
-     * @return array{paths: list<string>, patterns: list<string>}
-     */
-    private function compileSkipMatchers(array $skipPaths): array
-    {
-        $skipMatchers = [
-            'paths'    => [],
-            'patterns' => [],
-        ];
-
-        foreach ($skipPaths as $skipPath) {
-            $absoluteSkipPath = Path::resolve(
-                Path::normalise($skipPath),
-                $this->normalisedBasePath
-            );
-
-            if (strpbrk($absoluteSkipPath, '*?[') !== false) {
-                $skipMatchers['patterns'][] = $absoluteSkipPath;
-
-                continue;
-            }
-
-            $skipMatchers['paths'][] = Path::normalise($absoluteSkipPath, canonicalise: true);
-        }
-
-        return $skipMatchers;
-    }
-
-    /**
-     * @param array{paths: list<string>, patterns: list<string>} $skipMatchers
-     */
-    private function isSkipped(string $path, array $skipMatchers): bool
-    {
-        if ($skipMatchers['paths'] === [] && $skipMatchers['patterns'] === []) {
-            return false;
-        }
-
-        $normalisedPath = Path::normalise($path, canonicalise: true);
-
-        foreach ($skipMatchers['paths'] as $skipPath) {
-            if ($normalisedPath === $skipPath || str_starts_with($normalisedPath, $skipPath . '/')) {
-                return true;
-            }
-        }
-
-        foreach ($skipMatchers['patterns'] as $skipPattern) {
-            if (fnmatch($skipPattern, $normalisedPath)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param array{paths: list<string>, patterns: list<string>} $skipMatchers
-     * @return string[]
-     */
-    private function phpFiles(string $path, array $skipMatchers): array
-    {
-        $files    = [];
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveCallbackFilterIterator(
-                new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
-                function (SplFileInfo $file) use ($skipMatchers): bool {
-                    $isRealDirectory = $file->isDir() && ! $file->isLink();
-                    if (! $isRealDirectory && $file->getExtension() !== 'php') {
-                        return false;
-                    }
-
-                    return ! $this->isSkipped($file->getPathname(), $skipMatchers);
-                }
-            ),
-            RecursiveIteratorIterator::LEAVES_ONLY
-        );
-
-        /** @var SplFileInfo $file */
-        foreach ($iterator as $file) {
-            $files[] = Path::normalise($file->getPathname(), canonicalise: true);
-        }
-
-        return $files;
     }
 }

--- a/src/File/PhpFileCollector.php
+++ b/src/File/PhpFileCollector.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\File;
+
+use Boundwize\StructArmed\Util\Path;
+use FilesystemIterator;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Recursively collects PHP files under a directory, pruning skipped paths
+ * while traversing so skipped directories are never descended into.
+ */
+final readonly class PhpFileCollector
+{
+    /**
+     * @return list<string>
+     */
+    public function collect(string $directory, SkipPathMatcher $skipPathMatcher): array
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+                static function (SplFileInfo $file) use ($skipPathMatcher): bool {
+                    $isRealDirectory = $file->isDir() && ! $file->isLink();
+                    if (! $isRealDirectory && $file->getExtension() !== 'php') {
+                        return false;
+                    }
+
+                    return ! $skipPathMatcher->isSkipped($file->getPathname());
+                }
+            ),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        $files = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            $files[] = Path::normalise($file->getPathname(), canonicalise: true);
+        }
+
+        return $files;
+    }
+}

--- a/src/File/SkipPathMatcher.php
+++ b/src/File/SkipPathMatcher.php
@@ -12,6 +12,7 @@ use function fnmatch;
 use function implode;
 use function ltrim;
 use function realpath;
+use function sort;
 use function str_starts_with;
 use function strlen;
 use function strpbrk;
@@ -30,7 +31,8 @@ use function substr;
  *
  * A glob pattern is matched against both the absolute path and the base-relative path.
  *
- * Instances are cached per (base path, skip paths) pair and memoise per-path
+ * Instances are cached per (base path, skip paths) pair, ignoring skip path
+ * order and duplicates, and memoise per-path
  * results, since the same decision is requested for the same file by many rules.
  */
 final class SkipPathMatcher
@@ -61,6 +63,9 @@ final class SkipPathMatcher
      */
     public static function compile(string $basePath, array $skipPaths): self
     {
+        $skipPaths = array_unique($skipPaths);
+        sort($skipPaths);
+
         $cacheKey = $basePath . "\0" . implode("\0", $skipPaths);
 
         return self::$instances[$cacheKey] ??= new self($basePath, $skipPaths);

--- a/src/File/SkipPathMatcher.php
+++ b/src/File/SkipPathMatcher.php
@@ -20,10 +20,15 @@ use function substr;
 /**
  * Compiles skip paths once and decides whether a given path is skipped.
  *
- * A skip path may be:
- *  - a path that exists relative to the current working directory (or absolute),
- *  - a path relative to the base path (a leading slash is treated as base-relative),
- *  - a glob pattern, matched against both the absolute path and the base-relative path.
+ * A non-glob skip path is matched as every location it may refer to, all at once:
+ *  - the canonical path on disk, if it exists (resolved from the current working
+ *    directory, or absolute),
+ *  - the path resolved against the base path (absolute paths are kept as-is),
+ *  - the path, stripped of leading slashes, appended to the base path.
+ * A leading slash therefore matches both the absolute location and the
+ * base-relative one; it does not scope the path to the base path.
+ *
+ * A glob pattern is matched against both the absolute path and the base-relative path.
  *
  * Instances are cached per (base path, skip paths) pair and memoise per-path
  * results, since the same decision is requested for the same file by many rules.

--- a/src/File/SkipPathMatcher.php
+++ b/src/File/SkipPathMatcher.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\File;
+
+use Boundwize\StructArmed\Util\Path;
+
+use function array_unique;
+use function array_values;
+use function fnmatch;
+use function implode;
+use function ltrim;
+use function realpath;
+use function str_starts_with;
+use function strlen;
+use function strpbrk;
+use function substr;
+
+/**
+ * Compiles skip paths once and decides whether a given path is skipped.
+ *
+ * A skip path may be:
+ *  - a path that exists relative to the current working directory (or absolute),
+ *  - a path relative to the base path (a leading slash is treated as base-relative),
+ *  - a glob pattern, matched against both the absolute path and the base-relative path.
+ *
+ * Instances are cached per (base path, skip paths) pair and memoise per-path
+ * results, since the same decision is requested for the same file by many rules.
+ */
+final class SkipPathMatcher
+{
+    /** @var array<string, self> */
+    private static array $instances = [];
+
+    private readonly string $normalisedBasePathWithSlash;
+
+    /**
+     * Canonical skip path prefixes, each with a trailing slash so a single
+     * str_starts_with() against "$path/" covers both exact and prefix matches.
+     *
+     * @var list<string>
+     */
+    private readonly array $pathPrefixesWithSlash;
+
+    /** @var list<string> */
+    private readonly array $patterns;
+
+    private readonly bool $hasMatchers;
+
+    /** @var array<string, bool> */
+    private array $results = [];
+
+    /**
+     * @param list<string> $skipPaths
+     */
+    public static function compile(string $basePath, array $skipPaths): self
+    {
+        $cacheKey = $basePath . "\0" . implode("\0", $skipPaths);
+
+        return self::$instances[$cacheKey] ??= new self($basePath, $skipPaths);
+    }
+
+    /**
+     * @param list<string> $skipPaths
+     */
+    private function __construct(string $basePath, array $skipPaths)
+    {
+        $normalisedBasePath                = Path::normalise($basePath, canonicalise: true);
+        $this->normalisedBasePathWithSlash = $normalisedBasePath . '/';
+
+        $pathPrefixes = [];
+        $patterns     = [];
+
+        foreach ($skipPaths as $skipPath) {
+            $normalisedSkipPath = Path::normalise($skipPath);
+
+            if (strpbrk($skipPath, '*?[') !== false) {
+                $patterns[] = $normalisedSkipPath;
+
+                continue;
+            }
+
+            $canonicalSkipPath = realpath($skipPath);
+            if ($canonicalSkipPath !== false) {
+                $pathPrefixes[] = Path::normalise($canonicalSkipPath);
+            }
+
+            $pathPrefixes[] = Path::normalise(
+                Path::resolve($normalisedSkipPath, $normalisedBasePath),
+                canonicalise: true
+            );
+
+            $baseRelativePath = ltrim($normalisedSkipPath, '/');
+            $pathPrefixes[]   = Path::normalise(
+                $baseRelativePath === ''
+                    ? $normalisedBasePath
+                    : $normalisedBasePath . '/' . $baseRelativePath,
+                canonicalise: true
+            );
+        }
+
+        $pathPrefixesWithSlash = [];
+        foreach (array_unique($pathPrefixes) as $pathPrefix) {
+            $pathPrefixesWithSlash[] = $pathPrefix . '/';
+        }
+
+        $this->pathPrefixesWithSlash = $pathPrefixesWithSlash;
+        $this->patterns              = array_values(array_unique($patterns));
+        $this->hasMatchers           = $pathPrefixesWithSlash !== [] || $this->patterns !== [];
+    }
+
+    public function isSkipped(string $path): bool
+    {
+        if (! $this->hasMatchers) {
+            return false;
+        }
+
+        return $this->results[$path] ??= $this->computeIsSkipped($path);
+    }
+
+    private function computeIsSkipped(string $path): bool
+    {
+        $normalisedPath = Path::normalise($path, canonicalise: true);
+        $pathWithSlash  = $normalisedPath . '/';
+
+        foreach ($this->pathPrefixesWithSlash as $pathPrefixWithSlash) {
+            if (str_starts_with($pathWithSlash, $pathPrefixWithSlash)) {
+                return true;
+            }
+        }
+
+        if ($this->patterns === []) {
+            return false;
+        }
+
+        $relativePath = str_starts_with($normalisedPath, $this->normalisedBasePathWithSlash)
+            ? substr($normalisedPath, strlen($this->normalisedBasePathWithSlash))
+            : $normalisedPath;
+
+        foreach ($this->patterns as $pattern) {
+            if (fnmatch($pattern, $normalisedPath) || fnmatch($pattern, $relativePath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rule/Rules/File/PhpFileFinder.php
+++ b/src/Rule/Rules/File/PhpFileFinder.php
@@ -4,25 +4,14 @@ declare(strict_types=1);
 
 namespace Boundwize\StructArmed\Rule\Rules\File;
 
-use AppendIterator;
 use Boundwize\StructArmed\Composer\Psr4PathResolver;
+use Boundwize\StructArmed\File\PhpFileCollector;
+use Boundwize\StructArmed\File\SkipPathMatcher;
 use Boundwize\StructArmed\Util\Path;
-use FilesystemIterator;
-use RecursiveCallbackFilterIterator;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use SplFileInfo;
 
 use function array_unique;
 use function array_values;
-use function fnmatch;
 use function is_dir;
-use function ltrim;
-use function realpath;
-use function str_starts_with;
-use function strlen;
-use function strpbrk;
-use function substr;
 
 final readonly class PhpFileFinder
 {
@@ -32,6 +21,7 @@ final readonly class PhpFileFinder
     public function __construct(
         private ?array $sourcePaths = null,
         private Psr4PathResolver $psr4PathResolver = new Psr4PathResolver(),
+        private PhpFileCollector $phpFileCollector = new PhpFileCollector(),
     ) {
     }
 
@@ -41,9 +31,8 @@ final readonly class PhpFileFinder
      */
     public function files(string $basePath, array $skipPaths = []): array
     {
-        $normalisedBase = Path::normalise($basePath, canonicalise: true);
-        $skipMatchers   = $this->compileSkipMatchers($normalisedBase, $skipPaths);
-        $append         = new AppendIterator();
+        $skipPathMatcher = SkipPathMatcher::compile($basePath, $skipPaths);
+        $files           = [];
 
         $sourcePaths = array_unique($this->sourcePaths ?? $this->psr4PathResolver->paths($basePath));
         foreach ($sourcePaths as $sourcePath) {
@@ -53,101 +42,13 @@ final readonly class PhpFileFinder
                 continue;
             }
 
-            $append->append(new RecursiveIteratorIterator(
-                new RecursiveCallbackFilterIterator(
-                    new RecursiveDirectoryIterator($fullPath, FilesystemIterator::SKIP_DOTS),
-                    function (SplFileInfo $file) use ($normalisedBase, $skipMatchers): bool {
-                        $isRealDirectory = $file->isDir() && ! $file->isLink();
-                        if (! $isRealDirectory && $file->getExtension() !== 'php') {
-                            return false;
-                        }
-
-                        return ! $this->isSkipped($file->getPathname(), $normalisedBase, $skipMatchers);
-                    }
-                ),
-                RecursiveIteratorIterator::LEAVES_ONLY
-            ));
-        }
-
-        $files = [];
-
-        /** @var SplFileInfo $file */
-        foreach ($append as $file) {
-            $files[] = Path::normalise($file->getPathname(), canonicalise: true);
+            foreach ($this->phpFileCollector->collect($fullPath, $skipPathMatcher) as $file) {
+                $files[] = $file;
+            }
         }
 
         // ensure nothing duplicated once more
         // avoid inner directory provided by multiple source paths
         return array_values(array_unique($files));
-    }
-
-    /**
-     * @param list<string> $skipPaths
-     * @return list<array{absolutePath: string|null, baseRelativePath: string, pattern: string|null}>
-     */
-    private function compileSkipMatchers(string $normalisedBase, array $skipPaths): array
-    {
-        $skipMatchers = [];
-
-        foreach ($skipPaths as $skipPath) {
-            $baseRelativePath = Path::normalise(ltrim($skipPath, '/'));
-            $fullSkipPath     = $baseRelativePath === '' ? $normalisedBase : $normalisedBase . '/' . $baseRelativePath;
-
-            $skipMatchers[] = [
-                'absolutePath'     => realpath($skipPath) !== false
-                    ? Path::normalise($skipPath, canonicalise: true)
-                    : null,
-                'baseRelativePath' => Path::normalise($fullSkipPath, canonicalise: true),
-                'pattern'          => strpbrk($skipPath, '*?[') !== false
-                    ? Path::normalise($skipPath)
-                    : null,
-            ];
-        }
-
-        return $skipMatchers;
-    }
-
-    /**
-     * @param list<array{absolutePath: string|null, baseRelativePath: string, pattern: string|null}> $skipMatchers
-     */
-    private function isSkipped(string $filePath, string $normalisedBase, array $skipMatchers): bool
-    {
-        if ($skipMatchers === []) {
-            return false;
-        }
-
-        $normalisedFile = Path::normalise($filePath, canonicalise: true);
-        $relativePath   = substr($normalisedFile, strlen($normalisedBase) + 1);
-
-        foreach ($skipMatchers as $skipMatcher) {
-            if (
-                $skipMatcher['absolutePath'] !== null
-                && (
-                    $normalisedFile === $skipMatcher['absolutePath']
-                    || str_starts_with($normalisedFile, $skipMatcher['absolutePath'] . '/')
-                )
-            ) {
-                return true;
-            }
-
-            if (
-                $normalisedFile === $skipMatcher['baseRelativePath']
-                || str_starts_with($normalisedFile, $skipMatcher['baseRelativePath'] . '/')
-            ) {
-                return true;
-            }
-
-            if (
-                $skipMatcher['pattern'] !== null
-                && (
-                    fnmatch($skipMatcher['pattern'], $normalisedFile)
-                    || fnmatch($skipMatcher['pattern'], $relativePath)
-                )
-            ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/tests/Analyser/AnalyserSkipPathsTest.php
+++ b/tests/Analyser/AnalyserSkipPathsTest.php
@@ -6,11 +6,13 @@ namespace Boundwize\StructArmed\Tests\Analyser;
 
 use Boundwize\StructArmed\Analyser\Analyser;
 use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\File\SkipPathMatcher;
 use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Analyser::class)]
+#[CoversClass(SkipPathMatcher::class)]
 final class AnalyserSkipPathsTest extends TestCase
 {
     public function testAnalyserComposesGlobalAndRuleSpecificSkipsForClassRules(): void

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -10,6 +10,8 @@ use Boundwize\StructArmed\Analyser\FileAnalysisProvider;
 use Boundwize\StructArmed\Analyser\Parallel\ParallelClassNodeExtractor;
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\File\PhpFileCollector;
+use Boundwize\StructArmed\File\SkipPathMatcher;
 use Boundwize\StructArmed\Preset\Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr15Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr1Preset;
@@ -44,6 +46,8 @@ use const DIRECTORY_SEPARATOR;
 
 #[CoversClass(Analyser::class)]
 #[CoversClass(ParallelClassNodeExtractor::class)]
+#[CoversClass(PhpFileCollector::class)]
+#[CoversClass(SkipPathMatcher::class)]
 final class AnalyserTest extends TestCase
 {
     use TemporaryDirectoryCleanupTrait;
@@ -1456,6 +1460,44 @@ final class AnalyserTest extends TestCase
         $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
         $this->assertStringEndsWith(
             '/src/Foo.php',
+            $this->normalisePath($ruleViolationCollection->forRule('source.must_be_final')[0]->file)
+        );
+    }
+
+    public function testAnalyserRootSkipPathSkipsAllFiles(): void
+    {
+        $basePath = $this->makeTempProject([
+            'src/Foo.php' => '<?php namespace App; class Foo {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Source', 'src/')
+            ->skip(['/'])
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['src/']);
+
+        $this->assertFalse($ruleViolationCollection->hasViolations());
+    }
+
+    public function testAnalyserAppliesGlobSkipToScanPathOutsideBasePath(): void
+    {
+        $basePath    = $this->makeTempProject([]);
+        $outsidePath = $this->makeTempProject([
+            'Foo.php'               => '<?php namespace App; class Foo {}',
+            'Ignored.generated.php' => '<?php namespace App; class Ignored {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Source', $outsidePath . '/')
+            ->skip(['*.generated.php'])
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, [$outsidePath . '/']);
+
+        $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
+        $this->assertStringEndsWith(
+            '/Foo.php',
             $this->normalisePath($ruleViolationCollection->forRule('source.must_be_final')[0]->file)
         );
     }

--- a/tests/File/SkipPathMatcherTest.php
+++ b/tests/File/SkipPathMatcherTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Tests\File;
+
+use Boundwize\StructArmed\File\SkipPathMatcher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SkipPathMatcher::class)]
+final class SkipPathMatcherTest extends TestCase
+{
+    public function testCompileReturnsSameInstanceForSameBasePathAndSkipPaths(): void
+    {
+        $this->assertSame(
+            SkipPathMatcher::compile('/project', ['src/', 'vendor/']),
+            SkipPathMatcher::compile('/project', ['src/', 'vendor/'])
+        );
+    }
+
+    public function testCompileReturnsSameInstanceRegardlessOfSkipPathOrder(): void
+    {
+        $this->assertSame(
+            SkipPathMatcher::compile('/project', ['src/', 'vendor/']),
+            SkipPathMatcher::compile('/project', ['vendor/', 'src/'])
+        );
+    }
+
+    public function testCompileReturnsSameInstanceRegardlessOfDuplicateSkipPaths(): void
+    {
+        $this->assertSame(
+            SkipPathMatcher::compile('/project', ['src/', 'vendor/']),
+            SkipPathMatcher::compile('/project', ['vendor/', 'src/', 'vendor/'])
+        );
+    }
+
+    public function testCompileReturnsDifferentInstanceForDifferentSkipPaths(): void
+    {
+        $this->assertNotSame(
+            SkipPathMatcher::compile('/project', ['src/']),
+            SkipPathMatcher::compile('/project', ['vendor/'])
+        );
+    }
+
+    public function testCompileReturnsDifferentInstanceForDifferentBasePath(): void
+    {
+        $this->assertNotSame(
+            SkipPathMatcher::compile('/project-a', ['src/']),
+            SkipPathMatcher::compile('/project-b', ['src/'])
+        );
+    }
+
+    public function testReorderedSkipPathsMatchIdentically(): void
+    {
+        $skipPathMatcher = SkipPathMatcher::compile('/project', ['vendor/', 'src/', 'src/']);
+
+        $this->assertTrue($skipPathMatcher->isSkipped('/project/src/Foo.php'));
+        $this->assertTrue($skipPathMatcher->isSkipped('/project/vendor/autoload.php'));
+        $this->assertFalse($skipPathMatcher->isSkipped('/project/lib/Bar.php'));
+    }
+}


### PR DESCRIPTION
Avoid repeated similar logic to avoid misspatch in one place, and other not yet patched.