### PR TITLE
 [perf] Reuse memoised file content hashes across cache lookups via shared FileHashCache

### DIFF
--- a/src/Cache/AnalysisCacheMetadataFactory.php
+++ b/src/Cache/AnalysisCacheMetadataFactory.php
@@ -10,7 +10,6 @@ use Composer\InstalledVersions;
 use function array_map;
 use function file_exists;
 use function hash;
-use function hash_file;
 use function json_encode;
 use function rtrim;
 use function sort;
@@ -20,6 +19,10 @@ use const JSON_THROW_ON_ERROR;
 
 final readonly class AnalysisCacheMetadataFactory
 {
+    public function __construct(private FileHashCache $fileHashCache = new FileHashCache())
+    {
+    }
+
     /**
      * @param list<string> $scanPaths
      * @param list<string> $files
@@ -57,7 +60,7 @@ final readonly class AnalysisCacheMetadataFactory
 
     public function fileHash(string $path): string
     {
-        return (string) hash_file('xxh128', $path);
+        return $this->fileHashCache->hash($path);
     }
 
     /**
@@ -75,9 +78,9 @@ final readonly class AnalysisCacheMetadataFactory
      */
     private function filesHash(array $files): string
     {
-        return hash('xxh128', json_encode(array_map(static fn(string $file): array => [
+        return hash('xxh128', json_encode(array_map(fn(string $file): array => [
             'file' => $file,
-            'hash' => (string) hash_file('xxh128', $file),
+            'hash' => $this->fileHashCache->hash($file),
         ], $files), JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR));
     }
 

--- a/src/Cache/AnalysisResultCache.php
+++ b/src/Cache/AnalysisResultCache.php
@@ -23,7 +23,6 @@ use function file_get_contents;
 use function file_put_contents;
 use function glob;
 use function hash;
-use function hash_file;
 use function is_array;
 use function is_bool;
 use function is_dir;
@@ -55,6 +54,8 @@ final class AnalysisResultCache
 
     private readonly string $cacheDirectory;
 
+    private readonly FileHashCache $fileHashCache;
+
     private bool $isCacheInitialised = false;
 
     public function __construct(
@@ -62,7 +63,9 @@ final class AnalysisResultCache
         ?string $cacheDirectory = null,
         private readonly string $configHash = '',
         private readonly string $composerGeneratedVersionHash = '',
+        ?FileHashCache $fileHashCache = null,
     ) {
+        $this->fileHashCache  = $fileHashCache ?? new FileHashCache();
         $basePath             = Path::normalise($basePath);
         $this->cacheDirectory = $cacheDirectory
             ? Path::resolve(Path::normalise($cacheDirectory), $basePath)
@@ -833,7 +836,7 @@ final class AnalysisResultCache
         return [
             'namespace' => $namespace,
             'file'      => $file,
-            'hash'      => (string) hash_file('xxh128', $file),
+            'hash'      => $this->fileHashCache->hash($file),
         ];
     }
 }

--- a/src/Cache/AnalysisResultCache.php
+++ b/src/Cache/AnalysisResultCache.php
@@ -126,6 +126,9 @@ final class AnalysisResultCache
     public function clear(): void
     {
         $this->isCacheInitialised = false;
+        // Clearing usually means source files may have changed (e.g. --fix
+        // rewrote them), so memoised content hashes must not outlive the cache.
+        $this->fileHashCache->clear();
 
         if (! is_dir($this->cacheDirectory)) {
             return;

--- a/src/Cache/FileHashCache.php
+++ b/src/Cache/FileHashCache.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Cache;
+
+use function hash_file;
+
+/**
+ * Memoises content hashes so a file scanned by both the complete-result
+ * manifest and the per-file class-node cache is only read from disk once
+ * per run. Source files are treated as immutable while an analysis runs;
+ * callers that modify files mid-run (e.g. --fix) must call {@see clear()}
+ * before re-hashing.
+ */
+final class FileHashCache
+{
+    /** @var array<string, string> */
+    private array $hashes = [];
+
+    public function hash(string $file): string
+    {
+        return $this->hashes[$file] ??= (string) hash_file('xxh128', $file);
+    }
+
+    public function clear(): void
+    {
+        $this->hashes = [];
+    }
+}

--- a/src/Cache/FileHashCache.php
+++ b/src/Cache/FileHashCache.php
@@ -20,7 +20,19 @@ final class FileHashCache
 
     public function hash(string $file): string
     {
-        return $this->hashes[$file] ??= (string) hash_file('xxh128', $file);
+        if (isset($this->hashes[$file])) {
+            return $this->hashes[$file];
+        }
+
+        $hash = hash_file('xxh128', $file);
+
+        // Failures are not memoised: a file that becomes readable later in the
+        // run must hash fresh instead of being pinned to ''.
+        if ($hash === false) {
+            return '';
+        }
+
+        return $this->hashes[$file] = $hash;
     }
 
     public function clear(): void

--- a/src/Cli/AnalyseCommand.php
+++ b/src/Cli/AnalyseCommand.php
@@ -167,8 +167,6 @@ final readonly class AnalyseCommand
 
             if ($fixedCount > 0) {
                 $analysisResultCache->clear();
-                // Fixes rewrote source files, so memoised content hashes are stale.
-                $fileHashCache->clear();
 
                 $files                             = $analyser->filesForAnalysis($architecture, $scanPaths);
                 $metadata                          = $analysisCacheMetadataFactory->metadata(

--- a/src/Cli/AnalyseCommand.php
+++ b/src/Cli/AnalyseCommand.php
@@ -11,6 +11,7 @@ use Boundwize\StructArmed\Baseline\Baseline;
 use Boundwize\StructArmed\Baseline\BaselineFilter;
 use Boundwize\StructArmed\Cache\AnalysisCacheMetadataFactory;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashCache;
 use Boundwize\StructArmed\Config\ConfigLoader;
 use Boundwize\StructArmed\Progress\ConsoleProgressBar;
 use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
@@ -106,14 +107,16 @@ final readonly class AnalyseCommand
         }
 
         $start                        = microtime(true);
-        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory();
+        $fileHashCache                = new FileHashCache();
+        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory($fileHashCache);
         $configHash                   = $analysisCacheMetadataFactory->fileHash($configFile);
         $composerGeneratedVersionHash = $analysisCacheMetadataFactory->composerGeneratedVersionHash();
         $analysisResultCache          = new AnalysisResultCache(
             $basePath,
             $architecture->getCacheDirectory(),
             $configHash,
-            $composerGeneratedVersionHash
+            $composerGeneratedVersionHash,
+            $fileHashCache
         );
         $classNodeCacheNamespace      = $analysisCacheMetadataFactory->classNodeCacheNamespace($basePath, $configHash);
         $analyser                     = new Analyser($basePath, $analysisResultCache, $classNodeCacheNamespace);
@@ -164,6 +167,8 @@ final readonly class AnalyseCommand
 
             if ($fixedCount > 0) {
                 $analysisResultCache->clear();
+                // Fixes rewrote source files, so memoised content hashes are stale.
+                $fileHashCache->clear();
 
                 $files                             = $analyser->filesForAnalysis($architecture, $scanPaths);
                 $metadata                          = $analysisCacheMetadataFactory->metadata(

--- a/src/PHPUnit/StructArmedExtension.php
+++ b/src/PHPUnit/StructArmedExtension.php
@@ -8,6 +8,7 @@ use Boundwize\StructArmed\Analyser\Analyser;
 use Boundwize\StructArmed\Baseline\BaselineFilter;
 use Boundwize\StructArmed\Cache\AnalysisCacheMetadataFactory;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashCache;
 use Boundwize\StructArmed\Config\ConfigLoader;
 use Boundwize\StructArmed\Exception\ViolationsFoundException;
 use Boundwize\StructArmed\Progress\ConsoleProgressBar;
@@ -41,14 +42,16 @@ final class StructArmedExtension implements Extension
 
         $architecture = ConfigLoader::load($configFile);
 
-        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory();
+        $fileHashCache                = new FileHashCache();
+        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory($fileHashCache);
         $configHash                   = $analysisCacheMetadataFactory->fileHash($configFile);
         $composerGeneratedVersionHash = $analysisCacheMetadataFactory->composerGeneratedVersionHash();
         $analysisResultCache          = new AnalysisResultCache(
             $basePath,
             $architecture->getCacheDirectory(),
             $configHash,
-            $composerGeneratedVersionHash
+            $composerGeneratedVersionHash,
+            $fileHashCache
         );
 
         if ($analysisResultCache->shouldInvalidate()) {

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -13,6 +13,7 @@ use Boundwize\StructArmed\Analyser\MethodNode;
 use Boundwize\StructArmed\Analyser\PropertyNode;
 use Boundwize\StructArmed\Cache\AnalysisCacheMetadataFactory;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashCache;
 use Boundwize\StructArmed\Rule\RuleViolation;
 use Boundwize\StructArmed\Rule\RuleViolationCollection;
 use Composer\InstalledVersions;
@@ -438,8 +439,10 @@ final class AnalysisResultCacheTest extends TestCase
                 $analysisCacheMetadataFactory->classNodeCacheNamespace($basePath, 'other-config-hash')
             );
 
+            // Content hashes are memoised per factory instance (one instance per
+            // run), so composer.json edits are observed by the next run's factory.
             file_put_contents($basePath . '/composer.json', '{"autoload":{"psr-4":{"App\\\\":"lib/"}}}');
-            $withComposer = $analysisCacheMetadataFactory->classNodeCacheNamespace($basePath, 'config-hash');
+            $withComposer = (new AnalysisCacheMetadataFactory())->classNodeCacheNamespace($basePath, 'config-hash');
 
             $this->assertNotSame($withoutComposer, $withComposer);
 
@@ -447,7 +450,7 @@ final class AnalysisResultCacheTest extends TestCase
 
             $this->assertNotSame(
                 $withComposer,
-                $analysisCacheMetadataFactory->classNodeCacheNamespace($basePath, 'config-hash')
+                (new AnalysisCacheMetadataFactory())->classNodeCacheNamespace($basePath, 'config-hash')
             );
         } finally {
             $this->removeTempDirectory($basePath);
@@ -1164,6 +1167,35 @@ final class AnalysisResultCacheTest extends TestCase
         try {
             $analysisResultCache->storeClassNodes($sourceFile, 'config', [$this->makeClassNode($sourceFile)]);
             file_put_contents($sourceFile, '<?php class Foo { public function changed(): void {} }');
+
+            // A fresh instance models the next run, which hashes files anew.
+            $nextRunCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+
+            $this->assertNull($nextRunCache->loadClassNodes($sourceFile, 'config'));
+        } finally {
+            unlink($sourceFile);
+            $this->removeTempDirectory($cacheDirectory);
+        }
+    }
+
+    public function testClassNodesHitStaleHashUntilSharedFileHashCacheIsCleared(): void
+    {
+        $cacheDirectory      = $this->createTempDirectory();
+        $sourceFile          = $cacheDirectory . '/Foo.php';
+        $fileHashCache       = new FileHashCache();
+        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, '', '', $fileHashCache);
+
+        file_put_contents($sourceFile, '<?php class Foo {}');
+
+        try {
+            $analysisResultCache->storeClassNodes($sourceFile, 'config', [$this->makeClassNode($sourceFile)]);
+            file_put_contents($sourceFile, '<?php class Foo { public function changed(): void {} }');
+
+            // Hashes are memoised for the lifetime of the run, so the stale
+            // entry still hits until the hash cache is cleared (the --fix flow).
+            $this->assertNotNull($analysisResultCache->loadClassNodes($sourceFile, 'config'));
+
+            $fileHashCache->clear();
 
             $this->assertNull($analysisResultCache->loadClassNodes($sourceFile, 'config'));
         } finally {

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -1178,12 +1178,14 @@ final class AnalysisResultCacheTest extends TestCase
         }
     }
 
-    public function testClassNodesHitStaleHashUntilSharedFileHashCacheIsCleared(): void
+    public function testClearRestoresFreshHashesForSubsequentStores(): void
     {
-        $cacheDirectory      = $this->createTempDirectory();
-        $sourceFile          = $cacheDirectory . '/Foo.php';
-        $fileHashCache       = new FileHashCache();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, '', '', $fileHashCache);
+        $cacheDirectory = $this->createTempDirectory();
+        // The source file must live outside the cache directory: clear() wipes
+        // the cache directory, and the source must survive it.
+        $sourceDirectory     = $this->createTempDirectory();
+        $sourceFile          = $sourceDirectory . '/Foo.php';
+        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, '', '', new FileHashCache());
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -1192,14 +1194,20 @@ final class AnalysisResultCacheTest extends TestCase
             file_put_contents($sourceFile, '<?php class Foo { public function changed(): void {} }');
 
             // Hashes are memoised for the lifetime of the run, so the stale
-            // entry still hits until the hash cache is cleared (the --fix flow).
+            // entry still hits until the cache is cleared (the --fix flow).
             $this->assertNotNull($analysisResultCache->loadClassNodes($sourceFile, 'config'));
 
-            $fileHashCache->clear();
+            $analysisResultCache->clear();
+            $analysisResultCache->storeClassNodes($sourceFile, 'config', [$this->makeClassNode($sourceFile)]);
 
-            $this->assertNull($analysisResultCache->loadClassNodes($sourceFile, 'config'));
+            // A next-run instance hashes the changed content anew; it only hits
+            // if the post-clear store recorded fresh hashes, not memoised ones.
+            $nextRunCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+
+            $this->assertNotNull($nextRunCache->loadClassNodes($sourceFile, 'config'));
         } finally {
             unlink($sourceFile);
+            $this->removeTempDirectory($sourceDirectory);
             $this->removeTempDirectory($cacheDirectory);
         }
     }

--- a/tests/Cache/FileHashCacheTest.php
+++ b/tests/Cache/FileHashCacheTest.php
@@ -35,7 +35,7 @@ final class FileHashCacheTest extends TestCase
     {
         $fileHashCache = new FileHashCache();
 
-        self::assertSame((string) hash_file('xxh128', $this->file), $fileHashCache->hash($this->file));
+        $this->assertSame((string) hash_file('xxh128', $this->file), $fileHashCache->hash($this->file));
     }
 
     public function testHashIsMemoisedUntilCleared(): void
@@ -45,19 +45,19 @@ final class FileHashCacheTest extends TestCase
 
         file_put_contents($this->file, '<?php echo "changed";');
 
-        self::assertSame($originalHash, $fileHashCache->hash($this->file));
+        $this->assertSame($originalHash, $fileHashCache->hash($this->file));
 
         $fileHashCache->clear();
 
         $changedHash = $fileHashCache->hash($this->file);
-        self::assertNotSame($originalHash, $changedHash);
-        self::assertSame((string) hash_file('xxh128', $this->file), $changedHash);
+        $this->assertNotSame($originalHash, $changedHash);
+        $this->assertSame((string) hash_file('xxh128', $this->file), $changedHash);
     }
 
     public function testMissingFileHashesToEmptyString(): void
     {
         $fileHashCache = new FileHashCache();
 
-        self::assertSame('', @$fileHashCache->hash($this->file . '.missing'));
+        $this->assertSame('', @$fileHashCache->hash($this->file . '.missing'));
     }
 }

--- a/tests/Cache/FileHashCacheTest.php
+++ b/tests/Cache/FileHashCacheTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Tests\Cache;
+
+use Boundwize\StructArmed\Cache\FileHashCache;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function file_put_contents;
+use function hash_file;
+use function random_bytes;
+use function sys_get_temp_dir;
+use function unlink;
+
+#[CoversClass(FileHashCache::class)]
+final class FileHashCacheTest extends TestCase
+{
+    private string $file;
+
+    protected function setUp(): void
+    {
+        $this->file = sys_get_temp_dir() . '/structarmed-file-hash-' . bin2hex(random_bytes(8)) . '.php';
+        file_put_contents($this->file, '<?php echo "original";');
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->file);
+    }
+
+    public function testHashMatchesHashFile(): void
+    {
+        $fileHashCache = new FileHashCache();
+
+        self::assertSame((string) hash_file('xxh128', $this->file), $fileHashCache->hash($this->file));
+    }
+
+    public function testHashIsMemoisedUntilCleared(): void
+    {
+        $fileHashCache = new FileHashCache();
+        $originalHash  = $fileHashCache->hash($this->file);
+
+        file_put_contents($this->file, '<?php echo "changed";');
+
+        self::assertSame($originalHash, $fileHashCache->hash($this->file));
+
+        $fileHashCache->clear();
+
+        $changedHash = $fileHashCache->hash($this->file);
+        self::assertNotSame($originalHash, $changedHash);
+        self::assertSame((string) hash_file('xxh128', $this->file), $changedHash);
+    }
+
+    public function testMissingFileHashesToEmptyString(): void
+    {
+        $fileHashCache = new FileHashCache();
+
+        self::assertSame('', @$fileHashCache->hash($this->file . '.missing'));
+    }
+}

--- a/tests/Cache/FileHashCacheTest.php
+++ b/tests/Cache/FileHashCacheTest.php
@@ -60,4 +60,20 @@ final class FileHashCacheTest extends TestCase
 
         $this->assertSame('', @$fileHashCache->hash($this->file . '.missing'));
     }
+
+    public function testFailedHashIsNotMemoised(): void
+    {
+        $missingFile   = $this->file . '.late';
+        $fileHashCache = new FileHashCache();
+
+        $this->assertSame('', @$fileHashCache->hash($missingFile));
+
+        file_put_contents($missingFile, '<?php echo "late";');
+
+        try {
+            $this->assertSame((string) hash_file('xxh128', $missingFile), $fileHashCache->hash($missingFile));
+        } finally {
+            unlink($missingFile);
+        }
+    }
 }

--- a/tests/Cli/StructArmedApplicationTest.php
+++ b/tests/Cli/StructArmedApplicationTest.php
@@ -569,6 +569,59 @@ PHP);
         }
     }
 
+    /**
+     * The post-fix re-analysis must store hashes of the rewritten files, not
+     * hashes memoised before the fix ran. If stale hashes were stored, the
+     * second run below would miss the cache and re-parse the fixed file.
+     */
+    public function testAnalyseCommandStoresFreshHashesAfterFix(): void
+    {
+        $basePath = $this->createProjectDirectoryWithImplicitMethodVisibilityViolation();
+        $progress = new class implements ProgressHandlerInterface {
+            public bool $started = false;
+
+            public function start(int $total): void
+            {
+                $this->started = true;
+            }
+
+            public function advance(string $file): void
+            {
+            }
+
+            public function finish(): void
+            {
+            }
+        };
+
+        try {
+            [$fixExitCode, $fixOutput] = $this->runApplication(
+                [
+                    'structarmed',
+                    'analyse',
+                    '--config=' . $basePath . '/structarmed.php',
+                    '--clear-cache',
+                    '--fix',
+                    '--no-progress',
+                ],
+                $basePath
+            );
+
+            [$secondExitCode, $secondOutput] = $this->runAnalyseCommand(
+                ['--config=' . $basePath . '/structarmed.php'],
+                $basePath,
+                $progress
+            );
+
+            $this->assertSame(0, $fixExitCode, $fixOutput);
+            $this->assertSame(0, $secondExitCode, $secondOutput);
+            $this->assertStringContainsString('No violations found', $secondOutput);
+            $this->assertFalse($progress->started);
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
     public function testAnalyseCommandTracksComposerJsonProgressAsSingleFile(): void
     {
         $basePath = $this->createProjectDirectoryWithMissingComposerPsr4Path();


### PR DESCRIPTION
compared `hash-once` branch and `main` branch run to vendor.


| Metric | `main` | `hash-once` |
|---|---|---|
| Files analyzed | 6288 | 6288 |
| Time | 3.93s | 3.75s |
| Improvement | — | ~0.18s faster (~4.6%) |
