### PR TITLE
perf: Avoid hashing unchanged files twice during incremental runs

### DIFF
--- a/src/Cache/AnalysisCacheMetadataFactory.php
+++ b/src/Cache/AnalysisCacheMetadataFactory.php
@@ -10,7 +10,6 @@ use Composer\InstalledVersions;
 use function array_map;
 use function file_exists;
 use function hash;
-use function hash_file;
 use function json_encode;
 use function rtrim;
 use function sort;
@@ -20,6 +19,10 @@ use const JSON_THROW_ON_ERROR;
 
 final readonly class AnalysisCacheMetadataFactory
 {
+    public function __construct(private FileHashProvider $fileHashProvider = new FileHashProvider())
+    {
+    }
+
     /**
      * @param list<string> $scanPaths
      * @param list<string> $files
@@ -57,7 +60,7 @@ final readonly class AnalysisCacheMetadataFactory
 
     public function fileHash(string $path): string
     {
-        return (string) hash_file('xxh128', $path);
+        return $this->fileHashProvider->hash($path);
     }
 
     /**
@@ -75,9 +78,9 @@ final readonly class AnalysisCacheMetadataFactory
      */
     private function filesHash(array $files): string
     {
-        return hash('xxh128', json_encode(array_map(static fn(string $file): array => [
+        return hash('xxh128', json_encode(array_map(fn(string $file): array => [
             'file' => $file,
-            'hash' => (string) hash_file('xxh128', $file),
+            'hash' => $this->fileHashProvider->hash($file),
         ], $files), JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR));
     }
 

--- a/src/Cache/AnalysisCacheMetadataFactory.php
+++ b/src/Cache/AnalysisCacheMetadataFactory.php
@@ -17,9 +17,12 @@ use function sort;
 use const JSON_INVALID_UTF8_SUBSTITUTE;
 use const JSON_THROW_ON_ERROR;
 
+/**
+ * @internal
+ */
 final readonly class AnalysisCacheMetadataFactory
 {
-    public function __construct(private FileHashProvider $fileHashProvider = new FileHashProvider())
+    public function __construct(private FileHashProvider $fileHashProvider)
     {
     }
 

--- a/src/Cache/AnalysisResultCache.php
+++ b/src/Cache/AnalysisResultCache.php
@@ -58,10 +58,10 @@ final class AnalysisResultCache
 
     public function __construct(
         string $basePath,
+        private readonly FileHashProvider $fileHashProvider,
         ?string $cacheDirectory = null,
         private readonly string $configHash = '',
         private readonly string $composerGeneratedVersionHash = '',
-        private readonly FileHashProvider $fileHashProvider = new FileHashProvider(),
     ) {
         $basePath             = Path::normalise($basePath);
         $this->cacheDirectory = $cacheDirectory

--- a/src/Cache/AnalysisResultCache.php
+++ b/src/Cache/AnalysisResultCache.php
@@ -23,7 +23,6 @@ use function file_get_contents;
 use function file_put_contents;
 use function glob;
 use function hash;
-use function hash_file;
 use function is_array;
 use function is_bool;
 use function is_dir;
@@ -62,6 +61,7 @@ final class AnalysisResultCache
         ?string $cacheDirectory = null,
         private readonly string $configHash = '',
         private readonly string $composerGeneratedVersionHash = '',
+        private readonly FileHashProvider $fileHashProvider = new FileHashProvider(),
     ) {
         $basePath             = Path::normalise($basePath);
         $this->cacheDirectory = $cacheDirectory
@@ -123,6 +123,7 @@ final class AnalysisResultCache
     public function clear(): void
     {
         $this->isCacheInitialised = false;
+        $this->fileHashProvider->clear();
 
         if (! is_dir($this->cacheDirectory)) {
             return;
@@ -833,7 +834,7 @@ final class AnalysisResultCache
         return [
             'namespace' => $namespace,
             'file'      => $file,
-            'hash'      => (string) hash_file('xxh128', $file),
+            'hash'      => $this->fileHashProvider->hash($file),
         ];
     }
 }

--- a/src/Cache/FileHashProvider.php
+++ b/src/Cache/FileHashProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Cache;
+
+use function hash_file;
+
+/**
+ * Provides memoised content hashes for files that are treated as immutable
+ * during a single analysis run.
+ */
+final class FileHashProvider
+{
+    /** @var array<string, string> */
+    private array $hashes = [];
+
+    public function hash(string $file): string
+    {
+        if (isset($this->hashes[$file])) {
+            return $this->hashes[$file];
+        }
+
+        $hash = hash_file('xxh128', $file);
+
+        if ($hash === false) {
+            return '';
+        }
+
+        return $this->hashes[$file] = $hash;
+    }
+
+    public function clear(): void
+    {
+        $this->hashes = [];
+    }
+}

--- a/src/Cli/AnalyseCommand.php
+++ b/src/Cli/AnalyseCommand.php
@@ -11,6 +11,7 @@ use Boundwize\StructArmed\Baseline\Baseline;
 use Boundwize\StructArmed\Baseline\BaselineFilter;
 use Boundwize\StructArmed\Cache\AnalysisCacheMetadataFactory;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashProvider;
 use Boundwize\StructArmed\Config\ConfigLoader;
 use Boundwize\StructArmed\Progress\ConsoleProgressBar;
 use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
@@ -106,14 +107,16 @@ final readonly class AnalyseCommand
         }
 
         $start                        = microtime(true);
-        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory();
+        $fileHashProvider             = new FileHashProvider();
+        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory($fileHashProvider);
         $configHash                   = $analysisCacheMetadataFactory->fileHash($configFile);
         $composerGeneratedVersionHash = $analysisCacheMetadataFactory->composerGeneratedVersionHash();
         $analysisResultCache          = new AnalysisResultCache(
             $basePath,
             $architecture->getCacheDirectory(),
             $configHash,
-            $composerGeneratedVersionHash
+            $composerGeneratedVersionHash,
+            $fileHashProvider
         );
         $classNodeCacheNamespace      = $analysisCacheMetadataFactory->classNodeCacheNamespace($basePath, $configHash);
         $analyser                     = new Analyser($basePath, $analysisResultCache, $classNodeCacheNamespace);

--- a/src/Cli/AnalyseCommand.php
+++ b/src/Cli/AnalyseCommand.php
@@ -113,10 +113,10 @@ final readonly class AnalyseCommand
         $composerGeneratedVersionHash = $analysisCacheMetadataFactory->composerGeneratedVersionHash();
         $analysisResultCache          = new AnalysisResultCache(
             $basePath,
+            $fileHashProvider,
             $architecture->getCacheDirectory(),
             $configHash,
-            $composerGeneratedVersionHash,
-            $fileHashProvider
+            $composerGeneratedVersionHash
         );
         $classNodeCacheNamespace      = $analysisCacheMetadataFactory->classNodeCacheNamespace($basePath, $configHash);
         $analyser                     = new Analyser($basePath, $analysisResultCache, $classNodeCacheNamespace);

--- a/src/Cli/ClearCacheCommand.php
+++ b/src/Cli/ClearCacheCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Boundwize\StructArmed\Cli;
 
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashProvider;
 use Boundwize\StructArmed\Config\ConfigLoader;
 use RuntimeException;
 
@@ -58,7 +59,7 @@ final readonly class ClearCacheCommand
             }
         }
 
-        (new AnalysisResultCache($basePath, $cacheDirectory))->clear();
+        (new AnalysisResultCache($basePath, new FileHashProvider(), $cacheDirectory))->clear();
 
         echo "StructArmed cache cleared.\n";
 

--- a/src/PHPUnit/StructArmedExtension.php
+++ b/src/PHPUnit/StructArmedExtension.php
@@ -8,6 +8,7 @@ use Boundwize\StructArmed\Analyser\Analyser;
 use Boundwize\StructArmed\Baseline\BaselineFilter;
 use Boundwize\StructArmed\Cache\AnalysisCacheMetadataFactory;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashProvider;
 use Boundwize\StructArmed\Config\ConfigLoader;
 use Boundwize\StructArmed\Exception\ViolationsFoundException;
 use Boundwize\StructArmed\Progress\ConsoleProgressBar;
@@ -41,14 +42,16 @@ final class StructArmedExtension implements Extension
 
         $architecture = ConfigLoader::load($configFile);
 
-        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory();
+        $fileHashProvider             = new FileHashProvider();
+        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory($fileHashProvider);
         $configHash                   = $analysisCacheMetadataFactory->fileHash($configFile);
         $composerGeneratedVersionHash = $analysisCacheMetadataFactory->composerGeneratedVersionHash();
         $analysisResultCache          = new AnalysisResultCache(
             $basePath,
             $architecture->getCacheDirectory(),
             $configHash,
-            $composerGeneratedVersionHash
+            $composerGeneratedVersionHash,
+            $fileHashProvider
         );
 
         if ($analysisResultCache->shouldInvalidate()) {

--- a/src/PHPUnit/StructArmedExtension.php
+++ b/src/PHPUnit/StructArmedExtension.php
@@ -48,10 +48,10 @@ final class StructArmedExtension implements Extension
         $composerGeneratedVersionHash = $analysisCacheMetadataFactory->composerGeneratedVersionHash();
         $analysisResultCache          = new AnalysisResultCache(
             $basePath,
+            $fileHashProvider,
             $architecture->getCacheDirectory(),
             $configHash,
-            $composerGeneratedVersionHash,
-            $fileHashProvider
+            $composerGeneratedVersionHash
         );
 
         if ($analysisResultCache->shouldInvalidate()) {

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -10,6 +10,7 @@ use Boundwize\StructArmed\Analyser\FileAnalysisProvider;
 use Boundwize\StructArmed\Analyser\Parallel\ParallelClassNodeExtractor;
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashProvider;
 use Boundwize\StructArmed\File\PhpFileCollector;
 use Boundwize\StructArmed\File\SkipPathMatcher;
 use Boundwize\StructArmed\Preset\Preset;
@@ -205,7 +206,7 @@ final class AnalyserTest extends TestCase
             'src/BaseHandler.php'    => '<?php namespace App; class BaseHandler {}',
             'src/HandlerFactory.php' => $factory,
         ]);
-        $analysisResultCache = new AnalysisResultCache($basePath, 'cache');
+        $analysisResultCache = new AnalysisResultCache($basePath, new FileHashProvider(), 'cache');
 
         $architecture = Architecture::define()
             ->layer('Source', 'src/')
@@ -234,7 +235,7 @@ final class AnalyserTest extends TestCase
             'src/BaseHandler.php'    => '<?php namespace App; class BaseHandler {}',
             'src/HandlerFactory.php' => $factory,
         ]);
-        $analysisResultCache = new AnalysisResultCache($basePath, 'cache');
+        $analysisResultCache = new AnalysisResultCache($basePath, new FileHashProvider(), 'cache');
 
         // A file-analysis rule makes the warm run load class nodes through the
         // file-analysis cache path, which must also restore anonymous class nodes.
@@ -285,7 +286,7 @@ final class AnalyserTest extends TestCase
             'src/OrderHandler.php'   => '<?php namespace App; final class OrderHandler extends BaseHandler {}',
             'src/PaymentHandler.php' => '<?php namespace App; class PaymentHandler {}',
         ]);
-        $analysisResultCache = new AnalysisResultCache($basePath, 'cache');
+        $analysisResultCache = new AnalysisResultCache($basePath, new FileHashProvider(), 'cache');
 
         $architecture = Architecture::define()
             ->layer('Source', 'src/')
@@ -310,7 +311,7 @@ final class AnalyserTest extends TestCase
             'src/BaseHandler.php'  => '<?php namespace App; class BaseHandler {}',
             'src/OrderHandler.php' => '<?php namespace App; final class OrderHandler extends BaseHandler {}',
         ]);
-        $analysisResultCache = new AnalysisResultCache($basePath, 'cache');
+        $analysisResultCache = new AnalysisResultCache($basePath, new FileHashProvider(), 'cache');
 
         $architecture = Architecture::define()
             ->layer('Source', 'src/')
@@ -1287,7 +1288,7 @@ final class AnalyserTest extends TestCase
             'src/Foo.php' => '<?php namespace App; final class Foo {}',
             'src/Bar.php' => '<?php namespace App; final class Bar {}',
         ]);
-        $analysisResultCache = new AnalysisResultCache($basePath, 'cache');
+        $analysisResultCache = new AnalysisResultCache($basePath, new FileHashProvider(), 'cache');
         $progress            = new class implements ProgressHandlerInterface {
             public int $total = 0;
 

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -13,6 +13,7 @@ use Boundwize\StructArmed\Analyser\MethodNode;
 use Boundwize\StructArmed\Analyser\PropertyNode;
 use Boundwize\StructArmed\Cache\AnalysisCacheMetadataFactory;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashProvider;
 use Boundwize\StructArmed\Rule\RuleViolation;
 use Boundwize\StructArmed\Rule\RuleViolationCollection;
 use Composer\InstalledVersions;
@@ -31,6 +32,7 @@ use function file_get_contents;
 use function file_put_contents;
 use function glob;
 use function hash;
+use function hash_file;
 use function is_dir;
 use function json_decode;
 use function json_encode;
@@ -447,7 +449,7 @@ final class AnalysisResultCacheTest extends TestCase
 
             $this->assertNotSame(
                 $withComposer,
-                $analysisCacheMetadataFactory->classNodeCacheNamespace($basePath, 'config-hash')
+                (new AnalysisCacheMetadataFactory())->classNodeCacheNamespace($basePath, 'config-hash')
             );
         } finally {
             $this->removeTempDirectory($basePath);
@@ -1165,9 +1167,38 @@ final class AnalysisResultCacheTest extends TestCase
             $analysisResultCache->storeClassNodes($sourceFile, 'config', [$this->makeClassNode($sourceFile)]);
             file_put_contents($sourceFile, '<?php class Foo { public function changed(): void {} }');
 
-            $this->assertNull($analysisResultCache->loadClassNodes($sourceFile, 'config'));
+            $nextRunCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+
+            $this->assertNull($nextRunCache->loadClassNodes($sourceFile, 'config'));
         } finally {
             unlink($sourceFile);
+            $this->removeTempDirectory($cacheDirectory);
+        }
+    }
+
+    public function testClearResetsSharedFileHashes(): void
+    {
+        $cacheDirectory      = $this->createTempDirectory();
+        $sourceDirectory     = $this->createTempDirectory();
+        $sourceFile          = $sourceDirectory . '/Foo.php';
+        $fileHashProvider    = new FileHashProvider();
+        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, '', '', $fileHashProvider);
+
+        file_put_contents($sourceFile, '<?php class Foo {}');
+
+        try {
+            $originalHash = $fileHashProvider->hash($sourceFile);
+            file_put_contents($sourceFile, '<?php final class Foo {}');
+
+            $this->assertSame($originalHash, $fileHashProvider->hash($sourceFile));
+
+            $analysisResultCache->clear();
+
+            $this->assertSame(hash_file('xxh128', $sourceFile), $fileHashProvider->hash($sourceFile));
+            $this->assertNotSame($originalHash, $fileHashProvider->hash($sourceFile));
+        } finally {
+            unlink($sourceFile);
+            $this->removeTempDirectory($sourceDirectory);
             $this->removeTempDirectory($cacheDirectory);
         }
     }

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -55,7 +55,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testGetCacheDirectoryReturnsConfiguredDirectory(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         try {
             $this->assertSame($cacheDirectory, $analysisResultCache->getCacheDirectory());
@@ -67,7 +67,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testStoresAndLoadsViolationCollection(): void
     {
         $cacheDirectory          = $this->createTempDirectory();
-        $analysisResultCache     = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache     = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
         $metadata                = ['configHash' => 'same', 'filesHash' => 'same'];
         $ruleViolationCollection = new RuleViolationCollection();
         $ruleViolationCollection->add(new RuleViolation(
@@ -104,7 +104,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testStoresViolationCollectionWithInvalidUtf8Text(): void
     {
         $cacheDirectory          = $this->createTempDirectory();
-        $analysisResultCache     = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache     = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
         $metadata                = ['configHash' => 'same', 'filesHash' => 'same'];
         $ruleViolationCollection = new RuleViolationCollection();
         $ruleViolationCollection->add(new RuleViolation(
@@ -133,7 +133,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testMissesWhenMetadataChanges(): void
     {
         $cacheDirectory          = $this->createTempDirectory();
-        $analysisResultCache     = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache     = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
         $ruleViolationCollection = new RuleViolationCollection();
 
         try {
@@ -151,7 +151,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testMissesWhenCacheFileDoesNotExist(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         try {
             $this->assertNotInstanceOf(
@@ -166,7 +166,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testMissesWhenCachePayloadIsNotObject(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($cacheDirectory . '/key.json', '["bad"]');
 
@@ -184,7 +184,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $metadata            = ['configHash' => 'same'];
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         $this->writeCachePayload($cacheDirectory, [
             'metadata'   => $metadata,
@@ -205,7 +205,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $metadata            = ['configHash' => 'same'];
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         $this->writeCachePayload($cacheDirectory, [
             'metadata'   => $metadata,
@@ -226,7 +226,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $metadata            = ['configHash' => 'same'];
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         $this->writeCachePayload($cacheDirectory, [
             'metadata'   => $metadata,
@@ -247,7 +247,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $metadata            = ['configHash' => 'same'];
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         $this->writeCachePayload($cacheDirectory, [
             'metadata'   => $metadata,
@@ -276,8 +276,20 @@ final class AnalysisResultCacheTest extends TestCase
     public function testDetectsDifferentConfigHashAndClearsCache(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $staleCache          = new AnalysisResultCache(__DIR__, $cacheDirectory, 'old', 'composer-hash');
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, 'new', 'composer-hash');
+        $staleCache          = new AnalysisResultCache(
+            __DIR__,
+            new FileHashProvider(),
+            $cacheDirectory,
+            'old',
+            'composer-hash',
+        );
+        $analysisResultCache = new AnalysisResultCache(
+            __DIR__,
+            new FileHashProvider(),
+            $cacheDirectory,
+            'new',
+            'composer-hash',
+        );
 
         try {
             $staleCache->store('key', ['configHash' => 'old'], new RuleViolationCollection());
@@ -300,7 +312,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testClearRemovesEmptyCacheSubdirectories(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         mkdir($cacheDirectory . '/nested');
 
@@ -316,7 +328,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testCacheMetadataIsNotDifferentWhenCacheDirectoryIsMissing(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         $this->removeTempDirectory($cacheDirectory);
 
@@ -326,7 +338,13 @@ final class AnalysisResultCacheTest extends TestCase
     public function testConfigHashIsNotDifferentWhenStoredHashMatches(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, 'same', 'composer-hash');
+        $analysisResultCache = new AnalysisResultCache(
+            __DIR__,
+            new FileHashProvider(),
+            $cacheDirectory,
+            'same',
+            'composer-hash',
+        );
 
         try {
             $analysisResultCache->store('key', ['configHash' => 'same'], new RuleViolationCollection());
@@ -340,7 +358,13 @@ final class AnalysisResultCacheTest extends TestCase
     public function testInvalidationIgnoresUnreadableCachePayloadsAndDirectories(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, 'same', 'composer-hash');
+        $analysisResultCache = new AnalysisResultCache(
+            __DIR__,
+            new FileHashProvider(),
+            $cacheDirectory,
+            'same',
+            'composer-hash',
+        );
 
         mkdir($cacheDirectory . '/nested');
         file_put_contents($cacheDirectory . '/key.json', '["bad"]');
@@ -362,7 +386,13 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, 'same', 'composer-hash');
+        $analysisResultCache = new AnalysisResultCache(
+            __DIR__,
+            new FileHashProvider(),
+            $cacheDirectory,
+            'same',
+            'composer-hash',
+        );
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -380,7 +410,13 @@ final class AnalysisResultCacheTest extends TestCase
     public function testPopulatedCacheWithoutMetadataMarkerIsInvalidated(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, 'same', 'composer-hash');
+        $analysisResultCache = new AnalysisResultCache(
+            __DIR__,
+            new FileHashProvider(),
+            $cacheDirectory,
+            'same',
+            'composer-hash',
+        );
 
         try {
             $this->writeCachePayload($cacheDirectory, [
@@ -397,7 +433,13 @@ final class AnalysisResultCacheTest extends TestCase
     public function testComposerGeneratedVersionHashIsNotDifferentWhenStoredHashMatches(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, 'config-hash', 'same');
+        $analysisResultCache = new AnalysisResultCache(
+            __DIR__,
+            new FileHashProvider(),
+            $cacheDirectory,
+            'config-hash',
+            'same',
+        );
 
         try {
             $analysisResultCache->store('key', [], new RuleViolationCollection());
@@ -411,8 +453,20 @@ final class AnalysisResultCacheTest extends TestCase
     public function testComposerGeneratedVersionHashIsDifferentWhenStoredHashDiffers(): void
     {
         $cacheDirectory      = $this->createTempDirectory();
-        $staleCache          = new AnalysisResultCache(__DIR__, $cacheDirectory, 'config-hash', 'old');
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, 'config-hash', 'new');
+        $staleCache          = new AnalysisResultCache(
+            __DIR__,
+            new FileHashProvider(),
+            $cacheDirectory,
+            'config-hash',
+            'old',
+        );
+        $analysisResultCache = new AnalysisResultCache(
+            __DIR__,
+            new FileHashProvider(),
+            $cacheDirectory,
+            'config-hash',
+            'new',
+        );
 
         try {
             $staleCache->store('key', [], new RuleViolationCollection());
@@ -426,7 +480,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testClassNodeCacheNamespaceDependsOnConfigAndComposerJson(): void
     {
         $basePath                     = $this->createTempDirectory();
-        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory();
+        $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory(new FileHashProvider());
 
         try {
             $withoutComposer = $analysisCacheMetadataFactory->classNodeCacheNamespace($basePath, 'config-hash');
@@ -447,9 +501,11 @@ final class AnalysisResultCacheTest extends TestCase
 
             file_put_contents($basePath . '/composer.json', '{"autoload":{"psr-4":{"App\\\\":"src/"}}}');
 
+            $nextRunMetadataFactory = new AnalysisCacheMetadataFactory(new FileHashProvider());
+
             $this->assertNotSame(
                 $withComposer,
-                (new AnalysisCacheMetadataFactory())->classNodeCacheNamespace($basePath, 'config-hash')
+                $nextRunMetadataFactory->classNodeCacheNamespace($basePath, 'config-hash')
             );
         } finally {
             $this->removeTempDirectory($basePath);
@@ -459,7 +515,7 @@ final class AnalysisResultCacheTest extends TestCase
     public function testStoreCreatesMissingCacheDirectory(): void
     {
         $basePath                = $this->createTempDirectory();
-        $analysisResultCache     = new AnalysisResultCache($basePath);
+        $analysisResultCache     = new AnalysisResultCache($basePath, new FileHashProvider());
         $ruleViolationCollection = new RuleViolationCollection();
 
         try {
@@ -480,7 +536,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $basePath            = $this->createTempDirectory();
         $cacheDirectory      = $basePath . '/var/cache/structarmed';
-        $analysisResultCache = new AnalysisResultCache($basePath, 'var/cache/structarmed');
+        $analysisResultCache = new AnalysisResultCache($basePath, new FileHashProvider(), 'var/cache/structarmed');
 
         try {
             mkdir($basePath . '/var');
@@ -506,7 +562,7 @@ final class AnalysisResultCacheTest extends TestCase
 
     public function testConfiguredWindowsAbsoluteCacheDirectoryIsUsedAsIs(): void
     {
-        $analysisResultCache = new AnalysisResultCache(__DIR__, 'C:/structarmed/cache');
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), 'C:/structarmed/cache');
 
         $this->assertFalse($analysisResultCache->shouldInvalidate());
     }
@@ -515,7 +571,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
         $classNodes          = [$this->makeClassNode($sourceFile)];
 
         file_put_contents($sourceFile, '<?php class Foo {}');
@@ -543,7 +599,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
         $classNodes          = [$this->makeClassNode($sourceFile)];
         $anonymousClassNodes = [
             new AnonymousClassNode(
@@ -582,7 +638,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
         $classNodes          = [$this->makeClassNode($sourceFile)];
 
         file_put_contents($sourceFile, '<?php class Foo {}');
@@ -626,7 +682,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -653,7 +709,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
         $classNodes          = [
             new ClassNode(
                 className:   "App\\Invalid\xB1Name",
@@ -689,7 +745,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/FooTrait.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php trait FooTrait {}');
 
@@ -727,7 +783,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Status.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php enum Status: string { case Draft = "draft"; }');
 
@@ -766,7 +822,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Middleware.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php interface Middleware extends BaseMiddleware {}');
 
@@ -805,7 +861,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -860,7 +916,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -913,7 +969,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -956,7 +1012,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -999,7 +1055,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $basePath            = $this->createTempDirectory();
         $sourceFile          = $basePath . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache($basePath);
+        $analysisResultCache = new AnalysisResultCache($basePath, new FileHashProvider());
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -1022,7 +1078,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -1039,7 +1095,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
         $fileAnalysis        = new FileAnalysis(
             file: $sourceFile,
             hasUtf8Bom: false,
@@ -1072,7 +1128,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -1130,7 +1186,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -1159,7 +1215,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -1167,7 +1223,7 @@ final class AnalysisResultCacheTest extends TestCase
             $analysisResultCache->storeClassNodes($sourceFile, 'config', [$this->makeClassNode($sourceFile)]);
             file_put_contents($sourceFile, '<?php class Foo { public function changed(): void {} }');
 
-            $nextRunCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+            $nextRunCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
             $this->assertNull($nextRunCache->loadClassNodes($sourceFile, 'config'));
         } finally {
@@ -1182,7 +1238,7 @@ final class AnalysisResultCacheTest extends TestCase
         $sourceDirectory     = $this->createTempDirectory();
         $sourceFile          = $sourceDirectory . '/Foo.php';
         $fileHashProvider    = new FileHashProvider();
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory, '', '', $fileHashProvider);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, $fileHashProvider, $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -1207,7 +1263,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
         $classNodes          = [$this->makeClassNode($sourceFile)];
 
         file_put_contents($sourceFile, '<?php class Foo {}');
@@ -1816,7 +1872,7 @@ final class AnalysisResultCacheTest extends TestCase
     {
         $cacheDirectory      = $this->createTempDirectory();
         $sourceFile          = $cacheDirectory . '/Foo.php';
-        $analysisResultCache = new AnalysisResultCache(__DIR__, $cacheDirectory);
+        $analysisResultCache = new AnalysisResultCache(__DIR__, new FileHashProvider(), $cacheDirectory);
 
         file_put_contents($sourceFile, '<?php class Foo {}');
 
@@ -1850,7 +1906,7 @@ final class AnalysisResultCacheTest extends TestCase
         file_put_contents($source, '<?php class Example {}');
 
         try {
-            $metadata = (new AnalysisCacheMetadataFactory())->metadata(
+            $metadata = (new AnalysisCacheMetadataFactory(new FileHashProvider()))->metadata(
                 $directory,
                 $config,
                 ['src'],
@@ -1864,8 +1920,8 @@ final class AnalysisResultCacheTest extends TestCase
             $this->assertIsString($metadata['composerGeneratedVersionHash']);
             $this->assertIsString($metadata['filesHash']);
             $this->assertSame(
-                (new AnalysisCacheMetadataFactory())->key($metadata),
-                (new AnalysisCacheMetadataFactory())->key($metadata)
+                (new AnalysisCacheMetadataFactory(new FileHashProvider()))->key($metadata),
+                (new AnalysisCacheMetadataFactory(new FileHashProvider()))->key($metadata)
             );
         } finally {
             if (file_exists($config)) {
@@ -1892,7 +1948,7 @@ final class AnalysisResultCacheTest extends TestCase
 
         $this->assertMatchesRegularExpression(
             '/^[a-f0-9]{32}$/',
-            (new AnalysisCacheMetadataFactory())->key($metadata)
+            (new AnalysisCacheMetadataFactory(new FileHashProvider()))->key($metadata)
         );
     }
 
@@ -1906,7 +1962,7 @@ final class AnalysisResultCacheTest extends TestCase
         file_put_contents($source, '<?php class Example {}');
 
         try {
-            $metadata = (new AnalysisCacheMetadataFactory())->metadata(
+            $metadata = (new AnalysisCacheMetadataFactory(new FileHashProvider()))->metadata(
                 $directory,
                 $config,
                 ['src'],
@@ -1953,7 +2009,7 @@ final class AnalysisResultCacheTest extends TestCase
 
             $this->assertSame(
                 hash('xxh128', json_encode(InstalledVersions::getRootPackage(), JSON_THROW_ON_ERROR)),
-                (new AnalysisCacheMetadataFactory())->composerGeneratedVersionHash()
+                (new AnalysisCacheMetadataFactory(new FileHashProvider()))->composerGeneratedVersionHash()
             );
         } finally {
             $installed->setValue(null, $origInstalled);
@@ -1972,7 +2028,7 @@ final class AnalysisResultCacheTest extends TestCase
         file_put_contents($source, '<?php class Example {}');
 
         try {
-            $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory();
+            $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory(new FileHashProvider());
             $metadataBefore               = $analysisCacheMetadataFactory->metadata(
                 $directory,
                 $config,
@@ -2012,8 +2068,8 @@ final class AnalysisResultCacheTest extends TestCase
         file_put_contents($source, '<?php class Example {}');
 
         try {
-            $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory();
-            $analysisResultCache          = new AnalysisResultCache($directory, $cacheDir);
+            $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory(new FileHashProvider());
+            $analysisResultCache          = new AnalysisResultCache($directory, new FileHashProvider(), $cacheDir);
             $metadataBefore               = $analysisCacheMetadataFactory->metadata(
                 $directory,
                 $config,

--- a/tests/Cache/FileHashProviderTest.php
+++ b/tests/Cache/FileHashProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Tests\Cache;
+
+use Boundwize\StructArmed\Cache\FileHashProvider;
+use Boundwize\StructArmed\Tests\Support\TemporaryDirectoryCleanupTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function hash_file;
+
+#[CoversClass(FileHashProvider::class)]
+final class FileHashProviderTest extends TestCase
+{
+    use TemporaryDirectoryCleanupTrait;
+
+    public function testReturnsXxh128ContentHash(): void
+    {
+        $file = $this->makeTemporaryFile('structarmed-file-hash');
+        file_put_contents($file, '<?php echo "original";');
+
+        $this->assertSame(hash_file('xxh128', $file), (new FileHashProvider())->hash($file));
+    }
+
+    public function testMemoisesHashUntilCleared(): void
+    {
+        $file = $this->makeTemporaryFile('structarmed-file-hash');
+        file_put_contents($file, '<?php echo "original";');
+
+        $fileHashProvider = new FileHashProvider();
+        $originalHash     = $fileHashProvider->hash($file);
+
+        file_put_contents($file, '<?php echo "changed";');
+
+        $this->assertSame($originalHash, $fileHashProvider->hash($file));
+
+        $fileHashProvider->clear();
+
+        $this->assertSame(hash_file('xxh128', $file), $fileHashProvider->hash($file));
+        $this->assertNotSame($originalHash, $fileHashProvider->hash($file));
+    }
+
+    public function testDoesNotMemoiseFailedHash(): void
+    {
+        $directory        = $this->makeTemporaryDirectory('structarmed-file-hash');
+        $file             = $directory . '/created-later.php';
+        $fileHashProvider = new FileHashProvider();
+
+        $this->assertSame('', @$fileHashProvider->hash($file));
+
+        file_put_contents($file, '<?php echo "created later";');
+
+        $this->assertSame(hash_file('xxh128', $file), $fileHashProvider->hash($file));
+    }
+}

--- a/tests/Cli/StructArmedApplicationTest.php
+++ b/tests/Cli/StructArmedApplicationTest.php
@@ -6,6 +6,7 @@ namespace Boundwize\StructArmed\Tests\Cli;
 
 use Boundwize\StructArmed\Baseline\Baseline;
 use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashProvider;
 use Boundwize\StructArmed\Cli\AnalyseCommand;
 use Boundwize\StructArmed\Cli\ClearCacheCommand;
 use Boundwize\StructArmed\Cli\InitCommand;
@@ -1630,7 +1631,7 @@ PHP;
 
     private function removeTempDirectory(string $basePath): void
     {
-        (new AnalysisResultCache($basePath))->clear();
+        (new AnalysisResultCache($basePath, new FileHashProvider()))->clear();
 
         if (file_exists($basePath . '/structarmed.php')) {
             unlink($basePath . '/structarmed.php');


### PR DESCRIPTION
## Benchmark

Lower is better.

| Scenario | Runs | `main` mean | Patch mean | Change | Median |
|---|---:|---:|---:|---:|---:|
| Warm full-result cache hit | 15 | 155.12 ms ± 2.46 | 157.18 ms ± 4.63 | +1.32% | 154.66 → 155.95 ms |
| Incremental run, 1 of 3,000 files changed | 20 | 279.81 ms ± 7.92 | 244.70 ms ± 7.35 | **−12.55%** | **277.90 → 243.19 ms** |

The incremental path is **1.14× faster** on average.

### Methodology

- Compared `main` (`0e3d22f`) with this patch (`0891af3`).
- 3,000 PHP files at 16 KiB each (~46.9 MiB total).
- Per-file caches were seeded before measurement.
- Incremental runs changed one file each iteration, forcing an aggregate cache miss while leaving 2,999 per-file entries reusable.
- Results alternated between revisions to reduce run-order bias.
- Sequential analysis, CLI OPcache disabled.
- PHP 8.4.24, macOS 15.7.5, arm64.