### PR TITLE
Fix: Make rule MayNotCallFunctionRule matching case insensitive

### DIFF
--- a/src/Analyser/ClassNode.php
+++ b/src/Analyser/ClassNode.php
@@ -12,6 +12,7 @@ use function preg_match;
 use function rtrim;
 use function str_ends_with;
 use function str_starts_with;
+use function strcasecmp;
 
 final class ClassNode
 {
@@ -152,7 +153,13 @@ final class ClassNode
 
     public function callsFunction(string $function): bool
     {
-        return in_array($function, $this->functionCalls, true);
+        foreach ($this->functionCalls as $functionCall) {
+            if (strcasecmp($functionCall, $function) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function usesLanguageConstruct(string $construct): bool

--- a/tests/Analyser/ClassNodeTest.php
+++ b/tests/Analyser/ClassNodeTest.php
@@ -115,6 +115,8 @@ final class ClassNodeTest extends TestCase
         $this->assertTrue($classNode->extendsInterface('App\\Contracts\\BaseOrderService'));
         $this->assertTrue($classNode->extendsInterface('App\\Contracts\\RootOrderService'));
         $this->assertTrue($classNode->callsFunction('var_dump'));
+        $this->assertTrue($classNode->callsFunction('VAR_DUMP'));
+        $this->assertFalse($classNode->callsFunction('array_map'));
         $this->assertTrue($classNode->accessesSuperglobals());
         $this->assertTrue($classNode->usesLanguageConstruct('exit'));
         $this->assertFalse($classNode->usesLanguageConstruct('eval'));

--- a/tests/Rule/Usage/MayNotCallFunctionRuleTest.php
+++ b/tests/Rule/Usage/MayNotCallFunctionRuleTest.php
@@ -49,6 +49,14 @@ final class MayNotCallFunctionRuleTest extends TestCase
         $this->assertStringContainsString('var_dump', $violation->message);
     }
 
+    public function testFunctionComparisonIsCaseInsensitive(): void
+    {
+        $mayNotCallFunctionRule = new MayNotCallFunctionRule(layer: 'Domain', function: 'var_dump');
+        $classNode              = $this->makeNode(['VAR_DUMP']);
+
+        $this->assertInstanceOf(RuleViolation::class, $mayNotCallFunctionRule->evaluate($classNode));
+    }
+
     public function testViolatesForDdFunction(): void
     {
         $mayNotCallFunctionRule = new MayNotCallFunctionRule(layer: 'Domain', function: 'dd');


### PR DESCRIPTION
function calls is case insensitive 

https://3v4l.org/FHWRm#v8.2.0

Note:

For classname, it currently need to be match, and the psr4 rules already cover class not match so that marked as violation early, so should be not needed  to have check on case insensitive (for now).