### PR TITLE
perf: Disable Xdebug in parallel workers by default

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,6 +77,34 @@ StructArmed runs in parallel by default. Disable parallel processing when debugg
 vendor/bin/structarmed analyse --disable-parallel
 ```
 
+### Xdebug In Parallel Workers
+
+To reduce worker startup and analysis overhead, StructArmed sets `XDEBUG_MODE=off` for parallel workers when the variable is not already defined. This has no effect when the Xdebug extension is not installed.
+
+Set `XDEBUG_MODE` explicitly to enable Xdebug in the workers. StructArmed preserves the configured value:
+
+```bash
+# Linux and macOS
+XDEBUG_MODE=debug vendor/bin/structarmed analyse
+
+# Enable multiple Xdebug modes
+XDEBUG_MODE=develop,debug vendor/bin/structarmed analyse
+```
+
+In PowerShell:
+
+```powershell
+$env:XDEBUG_MODE = "debug"
+vendor/bin/structarmed analyse
+```
+
+In Windows Command Prompt:
+
+```batch
+set XDEBUG_MODE=debug
+vendor\bin\structarmed analyse
+```
+
 ## Version Commands
 
 ```bash

--- a/src/Analyser/Parallel/ParallelClassNodeExtractor.php
+++ b/src/Analyser/Parallel/ParallelClassNodeExtractor.php
@@ -24,6 +24,7 @@ use function feof;
 use function file_put_contents;
 use function filesize;
 use function fread;
+use function getenv;
 use function is_array;
 use function is_dir;
 use function is_resource;
@@ -76,6 +77,7 @@ final readonly class ParallelClassNodeExtractor
         $script       = dirname(__DIR__, 3) . '/bin/structarmed.php';
         $processes    = [];
         $emitProgress = $progressHandler instanceof ProgressHandlerInterface;
+        $environment  = $this->workerEnvironment();
 
         foreach ($this->buildWorkerBuckets($files, $workerCount) as $chunk) {
             [
@@ -104,6 +106,8 @@ final readonly class ParallelClassNodeExtractor
                     2 => ['file', $stderrFile, 'w'],
                 ],
                 $pipes,
+                null,
+                $environment,
             );
 
             if ($process === false) {
@@ -264,6 +268,14 @@ final readonly class ParallelClassNodeExtractor
         }
 
         return new ExtractionResult($nodes, $fileAnalyses, $anonymousClassNodes);
+    }
+
+    /** @return array<string, string> */
+    private function workerEnvironment(): array
+    {
+        $environment = getenv();
+
+        return $environment + ['XDEBUG_MODE' => 'off'];
     }
 
     /**

--- a/tests/Analyser/Parallel/MockFunctions.php
+++ b/tests/Analyser/Parallel/MockFunctions.php
@@ -13,20 +13,29 @@ $GLOBALS['mock_proc_open']                 = false;
 $GLOBALS['mock_tempnam']                   = false;
 $GLOBALS['mock_file_get_contents_payload'] = null;
 $GLOBALS['mock_tracked_tempnam_files']     = [];
+$GLOBALS['mock_proc_open_environment']     = null;
 // phpcs:enable
 
 /**
  * @param list<string>|string $command
  * @param array<int, list<string>|resource> $descriptorspec
  * @param array<int, resource> $pipes
+ * @param array<string, string>|null $envVars
  */
-function proc_open(array|string $command, array $descriptorspec, array|null &$pipes): mixed
-{
+function proc_open(
+    array|string $command,
+    array $descriptorspec,
+    array|null &$pipes,
+    string|null $cwd = null,
+    array|null $envVars = null,
+): mixed {
+    $GLOBALS['mock_proc_open_environment'] = $envVars;
+
     if ($GLOBALS['mock_proc_open'] === true) {
         return false;
     }
 
-    return \proc_open($command, $descriptorspec, $pipes);
+    return \proc_open($command, $descriptorspec, $pipes, $cwd, $envVars);
 }
 
 function tempnam(string $directory, string $prefix): string|false

--- a/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
+++ b/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
@@ -13,6 +13,7 @@ use RuntimeException;
 
 use function bin2hex;
 use function file_put_contents;
+use function getenv;
 use function glob;
 use function is_dir;
 use function random_bytes;
@@ -108,6 +109,19 @@ PHP);
         $classNames = [$extractionResult->classNodes[0]->className, $extractionResult->classNodes[1]->className];
         $this->assertContains('App\\Domain\\Foo', $classNames);
         $this->assertContains('App\\Domain\\Bar', $classNames);
+    }
+
+    public function testWorkersDisableXdebugUnlessExplicitlyConfigured(): void
+    {
+        $dir  = $this->makeTemporaryDirectory('structarmed-parallel-test');
+        $file = $dir . '/Foo.php';
+        file_put_contents($file, '<?php final class Foo {}');
+
+        (new ParallelClassNodeExtractor($dir, [], [], 2))->extract([$file]);
+
+        $environment = $GLOBALS['mock_proc_open_environment'];
+        $this->assertIsArray($environment);
+        $this->assertSame(getenv('XDEBUG_MODE') ?: 'off', $environment['XDEBUG_MODE']);
     }
 
     public function testExtractReturnsWorkerFacts(): void


### PR DESCRIPTION
### Performance comparison

Benchmark configuration:

- Directory: `vendor/`
- PHP files: 7,274
- Workers: 8
- PHP: 8.4.24
- Default file analysis enabled
- Five alternating measured runs after one warm-up pair

| Run | Before: Xdebug inherited | After: worker Xdebug off |
|---:|---:|---:|
| 1 | 2.584 s | 1.362 s |
| 2 | 2.658 s | 1.331 s |
| 3 | 2.637 s | 1.408 s |
| 4 | 2.683 s | 1.385 s |
| 5 | 2.700 s | 1.401 s |
| **Average** | **2.653 s** | **1.377 s** |
| **Median** | **2.658 s** | **1.385 s** |

The optimized version is **48.1% faster on average**, saving approximately **1.275 seconds** per run and providing a **1.93× speedup**.