### PR TITLE
Fix PHPUnit extension elapsed time calculation

### DIFF
--- a/src/PHPUnit/StructArmedExtension.php
+++ b/src/PHPUnit/StructArmedExtension.php
@@ -42,6 +42,7 @@ final class StructArmedExtension implements Extension
 
         $architecture = ConfigLoader::load($configFile);
 
+        $start                        = microtime(true);
         $fileHashProvider             = new FileHashProvider();
         $analysisCacheMetadataFactory = new AnalysisCacheMetadataFactory($fileHashProvider);
         $configHash                   = $analysisCacheMetadataFactory->fileHash($configFile);
@@ -68,7 +69,6 @@ final class StructArmedExtension implements Extension
         $metadata = $analysisCacheMetadataFactory->metadata($basePath, $configFile, [], $files);
         $cacheKey = $analysisCacheMetadataFactory->key($metadata);
 
-        $start                   = microtime(true);
         $ruleViolationCollection = $analysisResultCache->load($cacheKey, $metadata);
 
         if (! $ruleViolationCollection instanceof RuleViolationCollection) {


### PR DESCRIPTION
Make consistent with `AnalyseCommand`, start early before `FileHashProvider` definition.

https://github.com/boundwize/structarmed/blob/adbbe7dc068ce39bc5e541f35a345e18238498ed/src/Cli/AnalyseCommand.php#L109-L110