### PR TITLE
feat(cli): add `layers` command to print registered layers

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,6 +77,20 @@ StructArmed runs in parallel by default. Disable parallel processing when debugg
 vendor/bin/structarmed analyse --disable-parallel
 ```
 
+## Layers Commands
+
+List every layer registered in the config, including layers contributed by presets, without running an analysis.
+
+```bash
+# Layers from the discovered config.
+vendor/bin/structarmed layers
+
+# Custom config path.
+vendor/bin/structarmed layers --config=path/to/structarmed.php
+```
+
+Both path-based layers (`Architecture::layer()`) and namespace/regex layers (`Architecture::layerPattern()`) are printed. Preset-contributed layers are included automatically. Exits with code `1` and an error message when no config file is found.
+
 ## Version Commands
 
 ```bash

--- a/src/Cli/LayersCommand.php
+++ b/src/Cli/LayersCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Cli;
+
+use Boundwize\StructArmed\Config\ConfigLoader;
+use RuntimeException;
+
+use function count;
+use function explode;
+use function implode;
+use function is_array;
+use function sprintf;
+
+use const PHP_EOL;
+
+/**
+ * Prints all layers registered in the architecture config, including those
+ * contributed by presets, without running a full analysis.
+ */
+final readonly class LayersCommand
+{
+    /**
+     * @param list<string> $arguments
+     */
+    public function run(array $arguments, string $basePath): int
+    {
+        $configFile = null;
+        $counter    = count($arguments);
+
+        for ($index = 0; $index < $counter; $index++) {
+            $argument         = $arguments[$index];
+            [$option, $value] = explode('=', $argument, 2) + [1 => null];
+
+            if ($option === '--config') {
+                $configFile = $value ?? $arguments[++$index] ?? '';
+                continue;
+            }
+
+            echo sprintf("Unknown option: %s\n\n", $argument);
+            echo Usage::render();
+
+            return 1;
+        }
+
+        try {
+            if ($configFile === null) {
+                $configFile = ConfigLoader::discover($basePath);
+            }
+
+            $architecture = ConfigLoader::load($configFile);
+        } catch (RuntimeException $runtimeException) {
+            echo 'Error: ' . $runtimeException->getMessage() . PHP_EOL;
+
+            return 1;
+        }
+
+        $layers        = $architecture->getLayers();
+        $layerPatterns = $architecture->getLayerPatterns();
+
+        if ($layers === [] && $layerPatterns === []) {
+            echo "No layers registered.\n";
+
+            return 0;
+        }
+
+        foreach ($layers as $name => $paths) {
+            $pathList = is_array($paths) ? $paths : [$paths];
+
+            echo sprintf(
+                "  %-24s path   %s\n",
+                $name,
+                implode(', ', $pathList)
+            );
+        }
+
+        foreach ($layerPatterns as $name => $definition) {
+            $patternList = is_array($definition['pattern'])
+                ? $definition['pattern']
+                : [$definition['pattern']];
+
+            echo sprintf(
+                "  %-24s regex  %s\n",
+                $name,
+                implode(', ', $patternList)
+            );
+        }
+
+        return 0;
+    }
+}

--- a/src/Cli/StructArmedApplication.php
+++ b/src/Cli/StructArmedApplication.php
@@ -42,6 +42,10 @@ final readonly class StructArmedApplication
             return (new InitCommand())->run(array_slice($argv, 2), $basePath);
         }
 
+        if ($command === 'layers') {
+            return (new LayersCommand())->run(array_slice($argv, 2), $basePath);
+        }
+
         if ($command === '--clear-cache') {
             return (new ClearCacheCommand())->run(array_slice($argv, 2), $basePath);
         }

--- a/src/Cli/Usage.php
+++ b/src/Cli/Usage.php
@@ -12,6 +12,7 @@ final class Usage
 Usage:
   structarmed --version
   structarmed init [--preset=ddd|mvc|psr1|psr12|psr15|psr4|all]
+  structarmed layers [--config=path/to/structarmed.php]
   structarmed analyse|analyze [path ...] [--config=path/to/structarmed.php]
     [--report=console|json] [--no-progress] [--clear-cache] [--disable-parallel]
     [--fix] [--generate-baseline=structarmed-baseline.php]

--- a/tests/Cli/LayersCommandTest.php
+++ b/tests/Cli/LayersCommandTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Tests\Cli;
+
+use Boundwize\StructArmed\Cli\LayersCommand;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function file_exists;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function ob_end_clean;
+use function ob_get_contents;
+use function ob_start;
+use function random_bytes;
+use function rmdir;
+use function sys_get_temp_dir;
+use function unlink;
+
+#[CoversClass(LayersCommand::class)]
+final class LayersCommandTest extends TestCase
+{
+    public function testListsPathAndPatternLayersIncludingPresetLayers(): void
+    {
+        $basePath = $this->createTempDirectory();
+        $this->writeConfig($basePath, <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+
+return Architecture::define()
+    ->layer('Domain', 'src/Domain/')
+    ->layer('Application', ['src/Application/', 'src/App/'])
+    ->layerPattern('API', '/^App\\\\API\\\\.*$/')
+    ->withPreset(Preset::MVC());
+PHP);
+
+        try {
+            [$exitCode, $output] = $this->runLayers([], $basePath);
+
+            $this->assertSame(0, $exitCode, $output);
+            $this->assertStringContainsString('Domain', $output);
+            $this->assertStringContainsString('src/Domain/', $output);
+            $this->assertStringContainsString('Application', $output);
+            $this->assertStringContainsString('src/Application/, src/App/', $output);
+            $this->assertStringContainsString('API', $output);
+            $this->assertStringContainsString('/^App\\\\API\\\\.*$/', $output);
+            $this->assertStringContainsString('Controller', $output);
+            $this->assertStringContainsString('src/Controller/', $output);
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
+    public function testReportsNoLayersRegistered(): void
+    {
+        $basePath = $this->createTempDirectory();
+        $this->writeConfig($basePath, <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+
+return Architecture::define();
+PHP);
+
+        try {
+            [$exitCode, $output] = $this->runLayers([], $basePath);
+
+            $this->assertSame(0, $exitCode, $output);
+            $this->assertStringContainsString('No layers registered.', $output);
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
+    public function testUsesExplicitConfigWithEqualsOption(): void
+    {
+        $basePath = $this->createTempDirectory();
+        $this->writeConfig($basePath, <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+
+return Architecture::define()
+    ->layer('Domain', 'src/Domain/');
+PHP);
+
+        try {
+            [$exitCode, $output] = $this->runLayers(['--config=' . $basePath . '/structarmed.php'], $basePath);
+
+            $this->assertSame(0, $exitCode, $output);
+            $this->assertStringContainsString('Domain', $output);
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
+    public function testUsesExplicitConfigWithSeparateOptionValue(): void
+    {
+        $basePath = $this->createTempDirectory();
+        $this->writeConfig($basePath, <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+
+return Architecture::define()
+    ->layer('Domain', 'src/Domain/');
+PHP);
+
+        try {
+            [$exitCode, $output] = $this->runLayers(['--config', $basePath . '/structarmed.php'], $basePath);
+
+            $this->assertSame(0, $exitCode, $output);
+            $this->assertStringContainsString('Domain', $output);
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
+    public function testRejectsUnknownOption(): void
+    {
+        $basePath = $this->createTempDirectory();
+
+        try {
+            [$exitCode, $output] = $this->runLayers(['--bogus'], $basePath);
+
+            $this->assertSame(1, $exitCode);
+            $this->assertStringContainsString('Unknown option: --bogus', $output);
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
+    public function testReportsMissingConfig(): void
+    {
+        $basePath = $this->createTempDirectory();
+
+        try {
+            [$exitCode, $output] = $this->runLayers([], $basePath);
+
+            $this->assertSame(1, $exitCode);
+            $this->assertStringContainsString(
+                'Could not find a structarmed.php config file.',
+                $output
+            );
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
+    /**
+     * @param list<string> $arguments
+     * @return array{int, string}
+     */
+    private function runLayers(array $arguments, string $basePath): array
+    {
+        ob_start();
+        $exitCode = (new LayersCommand())->run($arguments, $basePath);
+        $output   = ob_get_contents();
+        ob_end_clean();
+
+        return [$exitCode, (string) $output];
+    }
+
+    private function writeConfig(string $basePath, string $config): void
+    {
+        file_put_contents($basePath . '/structarmed.php', $config);
+    }
+
+    private function createTempDirectory(): string
+    {
+        $basePath = sys_get_temp_dir() . '/structarmed-layers-' . bin2hex(random_bytes(6));
+        mkdir($basePath);
+
+        return $basePath;
+    }
+
+    private function removeTempDirectory(string $basePath): void
+    {
+        if (file_exists($basePath . '/structarmed.php')) {
+            unlink($basePath . '/structarmed.php');
+        }
+
+        if (is_dir($basePath)) {
+            rmdir($basePath);
+        }
+    }
+}

--- a/tests/Cli/StructArmedApplicationTest.php
+++ b/tests/Cli/StructArmedApplicationTest.php
@@ -10,6 +10,7 @@ use Boundwize\StructArmed\Cache\FileHashProvider;
 use Boundwize\StructArmed\Cli\AnalyseCommand;
 use Boundwize\StructArmed\Cli\ClearCacheCommand;
 use Boundwize\StructArmed\Cli\InitCommand;
+use Boundwize\StructArmed\Cli\LayersCommand;
 use Boundwize\StructArmed\Cli\StructArmedApplication;
 use Boundwize\StructArmed\Cli\Usage;
 use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
@@ -42,6 +43,7 @@ use function unlink;
 #[CoversClass(AnalyseCommand::class)]
 #[CoversClass(ClearCacheCommand::class)]
 #[CoversClass(InitCommand::class)]
+#[CoversClass(LayersCommand::class)]
 #[CoversClass(StructArmedApplication::class)]
 #[CoversClass(Usage::class)]
 #[CoversClass(Version::class)]
@@ -183,6 +185,80 @@ PHP);
             . "        Preset::MVC()\n"
             . "    );",
         ];
+    }
+
+    public function testApplicationPrintsLayersFromDiscoveredConfig(): void
+    {
+        $basePath = $this->createTempDirectory();
+        file_put_contents($basePath . '/structarmed.php', <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+
+return Architecture::define()
+    ->layer('Domain', 'src/Domain/')
+    ->withPreset(Preset::MVC());
+PHP);
+
+        try {
+            [$exitCode, $output] = $this->runApplication(['structarmed', 'layers'], $basePath);
+
+            $this->assertSame(0, $exitCode, $output);
+            $this->assertStringContainsString('Domain', $output);
+            $this->assertStringContainsString('src/Domain/', $output);
+            $this->assertStringContainsString('Controller', $output);
+            $this->assertStringContainsString('src/Controller/', $output);
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
+    public function testApplicationPrintsLayersFromExplicitConfig(): void
+    {
+        $basePath = $this->createTempDirectory();
+        file_put_contents($basePath . '/structarmed-custom.php', <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+
+return Architecture::define()
+    ->layerPattern('API', '/^App\\\\API\\\\.*$/');
+PHP);
+
+        try {
+            [$exitCode, $output] = $this->runApplication(
+                ['structarmed', 'layers', '--config=' . $basePath . '/structarmed-custom.php'],
+                $basePath
+            );
+
+            $this->assertSame(0, $exitCode, $output);
+            $this->assertStringContainsString('API', $output);
+            $this->assertStringContainsString('/^App\\\\API\\\\.*$/', $output);
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
+    }
+
+    public function testApplicationReportsMissingConfigForLayersCommand(): void
+    {
+        $basePath = $this->createTempDirectory();
+
+        try {
+            [$exitCode, $output] = $this->runApplication(['structarmed', 'layers'], $basePath);
+
+            $this->assertSame(1, $exitCode);
+            $this->assertStringContainsString(
+                'Could not find a structarmed.php config file.',
+                $output
+            );
+        } finally {
+            $this->removeTempDirectory($basePath);
+        }
     }
 
     /**


### PR DESCRIPTION
## What & why

Users need to see which layers an architecture actually has — especially the
layers contributed by presets (`Preset::MVC()`, `Preset::DDD()`, custom
presets), which are invisible in the config file until you trace preset
source. Today the only way to inspect layers is to read the config or run a
full analysis and infer them from violations.

This PR adds a dedicated command that lists every layer without analysing:

```bash
vendor/bin/structarmed layers [--config=path/to/structarmed.php]
```

Output covers both layer kinds:

```
  Source                   path   src/, tests/
  Controller               path   src/Controller/
  Controller               regex  /(?:^|\\)Controllers?(?:\\|$)/
```

- **path layers** from `Architecture::layer()` (`string` or `list<string>`)
- **regex/namespace layers** from `Architecture::layerPattern()`

Preset-contributed layers are included automatically because presets apply
when the config file is `require`d by `ConfigLoader::load()`.

## How it works

`LayersCommand` resolves the config (`--config` option, else
`ConfigLoader::discover()`), loads it with `ConfigLoader::load()`, and prints
`Architecture::getLayers()` and `Architecture::getLayerPatterns()`. No
`Analyser`, no file scan, no cache, no parallel workers — the config file is
the single source of truth.

## CLI surface

- New command: `structarmed layers [--config=path/to/structarmed.php]`
- `--config=...` and `--config <path>` both supported
- Exit `1` with a clean `Error: ...` message when the config file is missing
- Unknown options are rejected like the other commands
- Added to `Usage` help output and documented in `docs/cli.md`
