### PR TITLE
fix: Report "not analysable" instead of "not found" for existing non-analysable paths

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -988,11 +988,12 @@ final readonly class Analyser
                 canonicalise: true
             );
 
+            if ($skipPathMatcher->isSkipped($fullPath)) {
+                continue;
+            }
+
             if (is_file($fullPath)) {
-                if (
-                    Path::isAnalysableFile($fullPath, $this->basePath)
-                    && ! $skipPathMatcher->isSkipped($fullPath)
-                ) {
+                if (Path::isAnalysableFile($fullPath, $this->basePath)) {
                     $files[] = $fullPath;
                 }
 
@@ -1000,10 +1001,6 @@ final readonly class Analyser
             }
 
             if (! is_dir($fullPath)) {
-                continue;
-            }
-
-            if ($skipPathMatcher->isSkipped($fullPath)) {
                 continue;
             }
 

--- a/src/Cli/AnalyseCommand.php
+++ b/src/Cli/AnalyseCommand.php
@@ -87,16 +87,24 @@ final readonly class AnalyseCommand
         foreach ($scanPaths as $scanPath) {
             $fullScanPath = Path::resolve($scanPath, $basePath);
 
-            if (
-                is_dir($fullScanPath)
-                || (is_file($fullScanPath) && Path::isAnalysableFile($fullScanPath, $basePath))
-            ) {
+            if (is_dir($fullScanPath)) {
                 continue;
             }
 
-            echo sprintf("Error: path [%s] not found.\n", $scanPath);
+            if (! is_file($fullScanPath)) {
+                echo sprintf("Error: path [%s] not found.\n", $scanPath);
 
-            return 1;
+                return 1;
+            }
+
+            if (! Path::isAnalysableFile($fullScanPath, $basePath)) {
+                echo sprintf(
+                    "Error: path [%s] is not analysable. Expected a directory, a .php file, or the project composer.json.\n",
+                    $scanPath
+                );
+
+                return 1;
+            }
         }
 
         try {

--- a/src/Cli/AnalyseCommand.php
+++ b/src/Cli/AnalyseCommand.php
@@ -99,7 +99,8 @@ final readonly class AnalyseCommand
 
             if (! Path::isAnalysableFile($fullScanPath, $basePath)) {
                 echo sprintf(
-                    "Error: path [%s] is not analysable. Expected a directory, a .php file, or the project composer.json.\n",
+                    'Error: path [%s] is not analysable. '
+                        . "Expected a directory, a .php file, or the project composer.json.\n",
                     $scanPath
                 );
 

--- a/tests/Cli/StructArmedApplicationTest.php
+++ b/tests/Cli/StructArmedApplicationTest.php
@@ -664,7 +664,7 @@ PHP);
             );
 
             $this->assertSame(1, $nestedExitCode, $nestedOutput);
-            $this->assertStringContainsString('Error: path [nested/composer.json] not found.', $nestedOutput);
+            $this->assertStringContainsString('Error: path [nested/composer.json] is not analysable.', $nestedOutput);
         } finally {
             $this->removeTempDirectory($basePath);
         }
@@ -1399,7 +1399,10 @@ PHP);
             );
 
             $this->assertSame(1, $exitCode);
-            $this->assertStringContainsString('Error: path [readme.md] not found.', $output);
+            $this->assertStringContainsString(
+                'Error: path [readme.md] is not analysable. Expected a directory, a .php file, or the project composer.json.',
+                $output
+            );
         } finally {
             unlink($readmePath);
             rmdir($basePath);

--- a/tests/Cli/StructArmedApplicationTest.php
+++ b/tests/Cli/StructArmedApplicationTest.php
@@ -1400,7 +1400,8 @@ PHP);
 
             $this->assertSame(1, $exitCode);
             $this->assertStringContainsString(
-                'Error: path [readme.md] is not analysable. Expected a directory, a .php file, or the project composer.json.',
+                'Error: path [readme.md] is not analysable. '
+                    . 'Expected a directory, a .php file, or the project composer.json.',
                 $output
             );
         } finally {


### PR DESCRIPTION
**Before**

```
➜  vendor/bin/structarmed analyze README.md                                                            
Error: path [README.md] not found.
```

**After**

```
➜  vendor/bin/structarmed analyze README.md          
Error: path [README.md] is not analysable. Expected a directory, a .php file, or the project composer.json.
```