### PR TITLE
fix: Auto-resolve "Source" layer from composer PSR-4 paths when no Source layer is defined

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -74,7 +74,7 @@ final readonly class Analyser
     ): RuleViolationCollection {
         $ruleViolationCollection = new RuleViolationCollection();
 
-        $layers          = $this->resolveLayers($architecture);
+        $layers          = $this->resolveLayers($architecture, $scanPaths);
         $rules           = $architecture->getRules();
         $globalSkipPaths = $architecture->getSkipPaths();
         $ruleSkipPaths   = $architecture->getRuleSkipPaths();
@@ -1296,7 +1296,7 @@ final readonly class Analyser
      */
     public function filesForAnalysis(Architecture $architecture, array $scanPaths = [], ?array $layers = null): array
     {
-        $layers        ??= $this->resolveLayers($architecture);
+        $layers        ??= $this->resolveLayers($architecture, $scanPaths);
         $files           = [];
         $skipPathMatcher = SkipPathMatcher::compile($this->basePath, $architecture->getSkipPaths());
         $scanPaths       = $this->scanPaths($layers, $scanPaths);
@@ -1379,15 +1379,16 @@ final readonly class Analyser
     }
 
     /**
+     * @param list<string> $scanPaths
      * @return array<string, string|list<string>>
      */
-    private function resolveLayers(Architecture $architecture): array
+    private function resolveLayers(Architecture $architecture, array $scanPaths = []): array
     {
         $layers           = $architecture->getLayers();
         $sourcePaths      = $layers['Source'] ?? null;
         $sourceArrayPaths = $layers['Source[]'] ?? null;
 
-        if ($sourcePaths === []) {
+        if ($sourcePaths === [] || ($sourcePaths === null && $scanPaths === [])) {
             $sourcePaths      = (new Psr4PathResolver())->paths($this->basePath);
             $layers['Source'] = $sourcePaths;
         }

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -455,7 +455,8 @@ final readonly class Analyser
     /**
      * Empty layer paths are PSR-4 scan scopes resolved from composer.json, not
      * ruleset dependency layers. Classes found only through these layers are
-     * treated like external dependencies during ruleset checks.
+     * treated like external dependencies during ruleset checks. A 'Source'
+     * layer synthesised by resolveLayers() is a scan scope for the same reason.
      *
      * @return array<string, true>
      */
@@ -469,7 +470,22 @@ final readonly class Analyser
             }
         }
 
+        if ($this->isSourceSynthesised($architecture)) {
+            $scanScopeLayerMap['Source'] = true;
+        }
+
         return $scanScopeLayerMap;
+    }
+
+    /**
+     * Whether resolveLayers() fills the 'Source' layer from composer.json
+     * PSR-4 paths because the architecture leaves it undefined or empty.
+     */
+    private function isSourceSynthesised(Architecture $architecture): bool
+    {
+        $sourcePaths = $architecture->getLayers()['Source'] ?? null;
+
+        return $sourcePaths === null || $sourcePaths === [];
     }
 
     /**
@@ -1384,13 +1400,13 @@ final readonly class Analyser
     private function resolveLayers(Architecture $architecture): array
     {
         $layers           = $architecture->getLayers();
-        $sourcePaths      = $layers['Source'] ?? null;
         $sourceArrayPaths = $layers['Source[]'] ?? null;
 
-        if ($sourcePaths === null || $sourcePaths === []) {
-            $sourcePaths      = (new Psr4PathResolver())->paths($this->basePath);
-            $layers['Source'] = $sourcePaths;
+        if ($this->isSourceSynthesised($architecture)) {
+            $layers['Source'] = (new Psr4PathResolver())->paths($this->basePath);
         }
+
+        $sourcePaths = $layers['Source'] ?? [];
 
         if ($sourceArrayPaths === [] && $sourcePaths !== []) {
             $layers['Source[]'] = $sourcePaths;

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -74,7 +74,7 @@ final readonly class Analyser
     ): RuleViolationCollection {
         $ruleViolationCollection = new RuleViolationCollection();
 
-        $layers          = $this->resolveLayers($architecture, $scanPaths);
+        $layers          = $this->resolveLayers($architecture);
         $rules           = $architecture->getRules();
         $globalSkipPaths = $architecture->getSkipPaths();
         $ruleSkipPaths   = $architecture->getRuleSkipPaths();
@@ -1296,7 +1296,7 @@ final readonly class Analyser
      */
     public function filesForAnalysis(Architecture $architecture, array $scanPaths = [], ?array $layers = null): array
     {
-        $layers        ??= $this->resolveLayers($architecture, $scanPaths);
+        $layers        ??= $this->resolveLayers($architecture);
         $files           = [];
         $skipPathMatcher = SkipPathMatcher::compile($this->basePath, $architecture->getSkipPaths());
         $scanPaths       = $this->scanPaths($layers, $scanPaths);
@@ -1379,21 +1379,20 @@ final readonly class Analyser
     }
 
     /**
-     * @param list<string> $scanPaths
      * @return array<string, string|list<string>>
      */
-    private function resolveLayers(Architecture $architecture, array $scanPaths = []): array
+    private function resolveLayers(Architecture $architecture): array
     {
         $layers           = $architecture->getLayers();
         $sourcePaths      = $layers['Source'] ?? null;
         $sourceArrayPaths = $layers['Source[]'] ?? null;
 
-        if ($sourcePaths === [] || ($sourcePaths === null && $scanPaths === [])) {
+        if ($sourcePaths === null || $sourcePaths === []) {
             $sourcePaths      = (new Psr4PathResolver())->paths($this->basePath);
             $layers['Source'] = $sourcePaths;
         }
 
-        if ($sourceArrayPaths === [] && $sourcePaths !== null && $sourcePaths !== []) {
+        if ($sourceArrayPaths === [] && $sourcePaths !== []) {
             $layers['Source[]'] = $sourcePaths;
         }
 

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -1921,6 +1921,21 @@ final class AnalyserTest extends TestCase
         $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
     }
 
+    public function testAnalyserResolvesSourceFromComposerPsr4WithExplicitScanPaths(): void
+    {
+        $basePath = $this->makeTempProject([
+            'composer.json' => '{"autoload":{"psr-4":{"App\\\\":"app/"}}}',
+            'app/Foo.php'   => '<?php namespace App; class Foo {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture, ['app/']);
+
+        $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
+    }
+
     public function testFilesForAnalysisIncludesRootComposerJsonForComposerJsonRule(): void
     {
         $basePath = $this->makeTempProject([

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -29,6 +29,7 @@ use Boundwize\StructArmed\Rule\Rules\Layer\MayNotDependOnRule;
 use Boundwize\StructArmed\Rule\Rules\Method\MaxMethodLengthRule;
 use Boundwize\StructArmed\Rule\Rules\Usage\MayNotUseClassRule;
 use Boundwize\StructArmed\Rule\RuleViolation;
+use Boundwize\StructArmed\Rule\RuleViolationCollection;
 use Boundwize\StructArmed\Tests\Support\TemporaryDirectoryCleanupTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -1919,6 +1920,62 @@ final class AnalyserTest extends TestCase
         $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
 
         $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
+    }
+
+    public function testAnalyserReportsSameViolationsWithAndWithoutExplicitScanPaths(): void
+    {
+        $basePath = $this->makeTempProject([
+            'composer.json'          => '{"autoload":{"psr-4":{"App\\\\":"src/"}}}',
+            'src/Domain/Order.php'   => <<<'PHP'
+                <?php
+
+                namespace App\Domain;
+
+                use App\Support\Helper;
+
+                final class Order
+                {
+                    public function __construct(private Helper $helper) {}
+                }
+                PHP,
+            'src/Support/Helper.php' => <<<'PHP'
+                <?php
+
+                namespace App\Support;
+
+                class Helper {}
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Domain', 'src/Domain/')
+            ->layer('Infra', 'src/Infra/')
+            ->ruleset(['Domain' => ['Infra']])
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        $analyser = new Analyser($basePath);
+
+        $violationTuples = static function (RuleViolationCollection $ruleViolationCollection): array {
+            $tuples = [];
+            foreach ($ruleViolationCollection as $violation) {
+                $tuples[] = [$violation->ruleKey, $violation->className, $violation->message];
+            }
+
+            sort($tuples);
+
+            return $tuples;
+        };
+
+        $bareViolations     = $violationTuples($analyser->analyse($architecture));
+        $explicitViolations = $violationTuples($analyser->analyse($architecture, ['src/']));
+
+        // The synthesised Source layer classifies files identically whether the
+        // scan set comes from composer PSR-4 paths or explicit scan paths:
+        // the Source-targeted rule fires, the ruleset stays inert.
+        $this->assertSame($bareViolations, $explicitViolations);
+        $this->assertCount(1, $bareViolations);
+        $this->assertSame('source.must_be_final', $bareViolations[0][0]);
+        $this->assertSame('App\Support\Helper', $bareViolations[0][1]);
     }
 
     public function testFilesForAnalysisWidensScanToComposerPsr4PathsWhenSourceLayerIsNotDefined(): void

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -1921,6 +1921,26 @@ final class AnalyserTest extends TestCase
         $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
     }
 
+    public function testFilesForAnalysisWidensScanToComposerPsr4PathsWhenSourceLayerIsNotDefined(): void
+    {
+        $basePath = $this->makeTempProject([
+            'composer.json'        => '{"autoload":{"psr-4":{"App\\\\":"src/"}}}',
+            'src/Domain/Order.php' => '<?php namespace App\Domain; final class Order {}',
+            'src/Other/Helper.php' => '<?php namespace App\Other; final class Helper {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Domain', 'src/Domain/');
+
+        $files = array_map($this->normalisePath(...), (new Analyser($basePath))->filesForAnalysis($architecture));
+
+        sort($files);
+
+        $this->assertCount(2, $files);
+        $this->assertStringEndsWith('/src/Domain/Order.php', $files[0]);
+        $this->assertStringEndsWith('/src/Other/Helper.php', $files[1]);
+    }
+
     public function testAnalyserResolvesSourceFromComposerPsr4WithExplicitScanPaths(): void
     {
         $basePath = $this->makeTempProject([

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -1955,19 +1955,8 @@ final class AnalyserTest extends TestCase
 
         $analyser = new Analyser($basePath);
 
-        $violationTuples = static function (RuleViolationCollection $ruleViolationCollection): array {
-            $tuples = [];
-            foreach ($ruleViolationCollection as $violation) {
-                $tuples[] = [$violation->ruleKey, $violation->className, $violation->message];
-            }
-
-            sort($tuples);
-
-            return $tuples;
-        };
-
-        $bareViolations     = $violationTuples($analyser->analyse($architecture));
-        $explicitViolations = $violationTuples($analyser->analyse($architecture, ['src/']));
+        $bareViolations     = $this->violationTuples($analyser->analyse($architecture));
+        $explicitViolations = $this->violationTuples($analyser->analyse($architecture, ['src/']));
 
         // The synthesised Source layer classifies files identically whether the
         // scan set comes from composer PSR-4 paths or explicit scan paths:
@@ -1976,6 +1965,74 @@ final class AnalyserTest extends TestCase
         $this->assertCount(1, $bareViolations);
         $this->assertSame('source.must_be_final', $bareViolations[0][0]);
         $this->assertSame('App\Support\Helper', $bareViolations[0][1]);
+    }
+
+    public function testAnalyserReportsSameViolationsAcrossScanModesWithSharedCache(): void
+    {
+        $basePath = $this->makeTempProject([
+            'composer.json'          => '{"autoload":{"psr-4":{"App\\\\":"src/"}}}',
+            'src/Domain/Order.php'   => <<<'PHP'
+                <?php
+
+                namespace App\Domain;
+
+                use App\Support\Helper;
+
+                final class Order
+                {
+                    public function __construct(private Helper $helper) {}
+                }
+                PHP,
+            'src/Support/Helper.php' => <<<'PHP'
+                <?php
+
+                namespace App\Support;
+
+                class Helper {}
+                PHP,
+        ]);
+
+        $analysisResultCache = new AnalysisResultCache($basePath, new FileHashProvider(), 'cache');
+
+        $architecture = Architecture::define()
+            ->layer('Domain', 'src/Domain/')
+            ->layer('Infra', 'src/Infra/')
+            ->ruleset(['Domain' => ['Infra']])
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        // A result cached under one scan mode must not leak different layer
+        // semantics into the other: cold bare, warm explicit, warm bare.
+        $bareColdViolations     = $this->violationTuples(
+            (new Analyser($basePath, $analysisResultCache, 'config'))
+                ->analyse($architecture, [], null, AnalyserOptions::sequential())
+        );
+        $explicitWarmViolations = $this->violationTuples(
+            (new Analyser($basePath, $analysisResultCache, 'config'))
+                ->analyse($architecture, ['src/'], null, AnalyserOptions::sequential())
+        );
+        $bareWarmViolations     = $this->violationTuples(
+            (new Analyser($basePath, $analysisResultCache, 'config'))
+                ->analyse($architecture, [], null, AnalyserOptions::sequential())
+        );
+
+        $this->assertSame($bareColdViolations, $explicitWarmViolations);
+        $this->assertSame($bareColdViolations, $bareWarmViolations);
+        $this->assertCount(1, $bareColdViolations);
+        $this->assertSame('source.must_be_final', $bareColdViolations[0][0]);
+        $this->assertSame('App\Support\Helper', $bareColdViolations[0][1]);
+    }
+
+    /** @return list<array{string|null, string|null, string}> */
+    private function violationTuples(RuleViolationCollection $ruleViolationCollection): array
+    {
+        $tuples = [];
+        foreach ($ruleViolationCollection as $violation) {
+            $tuples[] = [$violation->ruleKey, $violation->className, $violation->message];
+        }
+
+        sort($tuples);
+
+        return $tuples;
     }
 
     public function testFilesForAnalysisWidensScanToComposerPsr4PathsWhenSourceLayerIsNotDefined(): void

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -1891,6 +1891,36 @@ final class AnalyserTest extends TestCase
         $this->assertStringEndsWith('/src/Foo.php', $files[0]);
     }
 
+    public function testFilesForAnalysisResolvesSourceFromComposerPsr4WhenSourceLayerIsNotDefined(): void
+    {
+        $basePath = $this->makeTempProject([
+            'composer.json' => '{"autoload":{"psr-4":{"App\\\\":"src/"}}}',
+            'src/Foo.php'   => '<?php namespace App; final class Foo {}',
+        ]);
+
+        $architecture = Architecture::define();
+
+        $files = array_map($this->normalisePath(...), (new Analyser($basePath))->filesForAnalysis($architecture));
+
+        $this->assertCount(1, $files);
+        $this->assertStringEndsWith('/src/Foo.php', $files[0]);
+    }
+
+    public function testAnalyserResolvesSourceFromComposerPsr4WhenSourceLayerIsNotDefined(): void
+    {
+        $basePath = $this->makeTempProject([
+            'composer.json' => '{"autoload":{"psr-4":{"App\\\\":"app/"}}}',
+            'app/Foo.php'   => '<?php namespace App; class Foo {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->rule('source.must_be_final', new MustBeFinalRule('Source'));
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
+
+        $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
+    }
+
     public function testFilesForAnalysisIncludesRootComposerJsonForComposerJsonRule(): void
     {
         $basePath = $this->makeTempProject([

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -1936,6 +1936,41 @@ final class AnalyserTest extends TestCase
         $this->assertCount(1, $ruleViolationCollection->forRule('source.must_be_final'));
     }
 
+    public function testSynthesisedSourceLayerIsRulesetInertLikeExplicitEmptySource(): void
+    {
+        $basePath = $this->makeTempProject([
+            'composer.json'          => '{"autoload":{"psr-4":{"App\\\\":"src/"}}}',
+            'src/Domain/Order.php'   => <<<'PHP'
+                <?php
+
+                namespace App\Domain;
+
+                use App\Support\Helper;
+
+                final class Order
+                {
+                    public function __construct(private Helper $helper) {}
+                }
+                PHP,
+            'src/Support/Helper.php' => <<<'PHP'
+                <?php
+
+                namespace App\Support;
+
+                final class Helper {}
+                PHP,
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Domain', 'src/Domain/')
+            ->layer('Infra', 'src/Infra/')
+            ->ruleset(['Domain' => ['Infra']]);
+
+        $ruleViolationCollection = (new Analyser($basePath))->analyse($architecture);
+
+        $this->assertFalse($ruleViolationCollection->hasViolations());
+    }
+
     public function testFilesForAnalysisIncludesRootComposerJsonForComposerJsonRule(): void
     {
         $basePath = $this->makeTempProject([


### PR DESCRIPTION
Make auto resolve `Source` layer when layer `Source` is not defined and the scan path is not written in cli params, so no longer need tweak set define empty `Source`:

```diff
        $architecture = Architecture::define()
-           // tweak to resolve paths from composer psr4 
-          ->layer('Source', []) 
            ->layerPattern('DataCaster', '/^CodeIgniter\\\\DataCaster\\\\.*$/')
            ->ruleset([
                'DataCaster' => [],
            ]);
```

when run:

```bash
vendor/bin/structarmed
```

When an explicit scan path is provided, such as:

```bash
vendor/bin/structarmed analyze src
```

the explicit path still controls what is scanned, while the automatically resolved Source layer is used for layer classification.

If user using presets, `Source` mostly already setup there.

https://github.com/boundwize/structarmed/blob/9b6e4d2812e2821aca9adde8df56af8e2fc8b0db/src/Preset/Presets/Psr4Preset.php#L32-L41

