### PR TITLE
fix: Avoid Source layer defined via layerPattern()

### DIFF
--- a/src/Architecture.php
+++ b/src/Architecture.php
@@ -140,13 +140,12 @@ final class Architecture
      */
     public function layerPattern(string $name, string|array $pattern, string|array|null $excludePattern = null): self
     {
-        if (preg_match('/^Source(?:\[[\w.\/-]*(?:,[\w.\/-]+)*\])?$/', $name, $matches)) {
-            $layerName = $matches[0];
+        if ($name === 'Source' || (str_starts_with($name, 'Source[') && str_ends_with($name, ']'))) {
             throw new InvalidArgumentException(
                 sprintf(
                     'Layer name "%s" is reserved for the path-based Source layer registered via ->layer(). '
                     . 'Use ->layer() to define source paths, or choose a different name for your layerPattern().',
-                    $layerName
+                    $name
                 )
             );
         }

--- a/src/Architecture.php
+++ b/src/Architecture.php
@@ -16,8 +16,9 @@ use function array_merge;
 use function array_unique;
 use function array_values;
 use function is_int;
-use function preg_match;
 use function sprintf;
+use function str_ends_with;
+use function str_starts_with;
 
 /**
  * Fluent architecture definition builder.

--- a/src/Architecture.php
+++ b/src/Architecture.php
@@ -8,6 +8,7 @@ use Boundwize\StructArmed\Exception\RuleNotFoundException;
 use Boundwize\StructArmed\Preset\PresetInterface;
 use Boundwize\StructArmed\Rule\ProjectRuleInterface;
 use Boundwize\StructArmed\Rule\RuleInterface;
+use InvalidArgumentException;
 
 use function array_filter;
 use function array_key_exists;
@@ -15,6 +16,7 @@ use function array_merge;
 use function array_unique;
 use function array_values;
 use function is_int;
+use function preg_match;
 use function sprintf;
 
 /**
@@ -138,6 +140,17 @@ final class Architecture
      */
     public function layerPattern(string $name, string|array $pattern, string|array|null $excludePattern = null): self
     {
+        if (preg_match('/^Source(?:\[[\w.\/-]*(?:,[\w.\/-]+)*\])?$/', $name, $matches)) {
+            $layerName = $matches[0];
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Layer name "%s" is reserved for the path-based Source layer registered via ->layer(). '
+                    . 'Use ->layer() to define source paths, or choose a different name for your layerPattern().',
+                    $layerName
+                )
+            );
+        }
+
         $this->layerPatterns[$name] = [
             'pattern'        => $pattern,
             'excludePattern' => $excludePattern,

--- a/tests/ArchitectureTest.php
+++ b/tests/ArchitectureTest.php
@@ -324,6 +324,8 @@ final class ArchitectureTest extends TestCase
         yield 'empty brackets' => ['Source[]'];
         yield 'single path' => ['Source[lib/]'];
         yield 'multiple paths' => ['Source[lib/,src/]'];
+        yield 'Windows absolute path' => ['Source[C:/project/src/]'];
+        yield 'path with spaces' => ['Source[my project/src/]'];
     }
 
     #[DataProvider('provideNonReservedLayerNames')]

--- a/tests/ArchitectureTest.php
+++ b/tests/ArchitectureTest.php
@@ -305,7 +305,12 @@ final class ArchitectureTest extends TestCase
     public function testLayerPatternRejectsReservedSourceLayerName(string $name): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('Layer name "%s" is reserved for the path-based Source layer registered via ->layer().', $name));
+        $this->expectExceptionMessage(
+            sprintf(
+                'Layer name "%s" is reserved for the path-based Source layer registered via ->layer().',
+                $name
+            )
+        );
 
         Architecture::define()->layerPattern($name, '/^App\\\\.*$/');
     }

--- a/tests/ArchitectureTest.php
+++ b/tests/ArchitectureTest.php
@@ -13,8 +13,12 @@ use Boundwize\StructArmed\Preset\Presets\Psr1Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr4Preset;
 use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4SourcePathsRule;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+
+use function sprintf;
 
 #[CoversClass(Architecture::class)]
 final class ArchitectureTest extends TestCase
@@ -295,6 +299,45 @@ final class ArchitectureTest extends TestCase
             '/Exception$/',
             '/^App\\\\HTTP\\\\URI$/',
         ], $patterns['HTTP']['excludePattern']);
+    }
+
+    #[DataProvider('provideReservedSourceLayerNames')]
+    public function testLayerPatternRejectsReservedSourceLayerName(string $name): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Layer name "%s" is reserved for the path-based Source layer registered via ->layer().', $name));
+
+        Architecture::define()->layerPattern($name, '/^App\\\\.*$/');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideReservedSourceLayerNames(): iterable
+    {
+        yield 'bare' => ['Source'];
+        yield 'empty brackets' => ['Source[]'];
+        yield 'single path' => ['Source[lib/]'];
+        yield 'multiple paths' => ['Source[lib/,src/]'];
+    }
+
+    #[DataProvider('provideNonReservedLayerNames')]
+    public function testLayerPatternAcceptsNonReservedLayerName(string $name): void
+    {
+        $architecture = Architecture::define()->layerPattern($name, '/^App\\\\.*$/');
+
+        $this->assertArrayHasKey($name, $architecture->getLayerPatterns());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideNonReservedLayerNames(): iterable
+    {
+        yield 'prefix' => ['SourceCode'];
+        yield 'lowercase' => ['source'];
+        yield 'unclosed bracket' => ['Source[lib/'];
+        yield 'other name' => ['HTTP'];
     }
 
     public function testRulesetIsRegistered(): void


### PR DESCRIPTION
`Source` should be defined via `layer()`, not `layerPattern()`, since auto detect it only on `getLayers()`

https://github.com/boundwize/structarmed/blob/0f99c2d05b9a6ad60562e2f6393f5ac968f645a4/src/Analyser/Analyser.php#L1401-L1417