### PR TITLE
[parallel] Make use of socket over pipe and stream_select() over usleep()

### DIFF
--- a/src/Analyser/Parallel/ParallelClassNodeExtractor.php
+++ b/src/Analyser/Parallel/ParallelClassNodeExtractor.php
@@ -401,8 +401,9 @@ final readonly class ParallelClassNodeExtractor
         $write  = null;
         $except = null;
 
-        // The timeout only bounds how long we wait when no worker writes anything. A false return
-        // (interrupted by a signal) degrades to polling every worker once, exactly as a timeout would.
+        // The timeout only bounds how long we wait when no worker writes anything; on timeout $read is
+        // empty and no worker is touched. On error (for example, interruption by a signal) fall back to
+        // polling every worker once so progress and EOF can still be detected.
         $selected = @stream_select($read, $write, $except, 0, 50000);
 
         return $selected === false ? $all : $read;

--- a/src/Analyser/Parallel/ParallelClassNodeExtractor.php
+++ b/src/Analyser/Parallel/ParallelClassNodeExtractor.php
@@ -14,7 +14,6 @@ use RuntimeException;
 
 use function array_fill;
 use function array_key_exists;
-use function array_keys;
 use function array_search;
 use function arsort;
 use function assert;
@@ -144,10 +143,14 @@ final readonly class ParallelClassNodeExtractor
         $failure             = null;
 
         while ($pending !== []) {
-            $anyActivity = false;
+            $readable = $this->readableWorkers($pending);
 
-            foreach (array_keys($pending) as $key) {
-                $stdoutPipe = $pending[$key]['stdoutPipe'];
+            foreach ($pending as $key => $worker) {
+                if (! isset($readable[$key])) {
+                    continue;
+                }
+
+                $stdoutPipe = $worker['stdoutPipe'];
 
                 $data = fread($stdoutPipe, 8192);
                 if ($data !== false && $data !== '') {
@@ -157,8 +160,6 @@ final readonly class ParallelClassNodeExtractor
                         $pending[$key]['filesAdvanced'] + substr_count($data, "\n"),
                         $progressHandler
                     );
-
-                    $anyActivity = true;
                 }
 
                 if (! feof($stdoutPipe)) {
@@ -350,11 +351,6 @@ final readonly class ParallelClassNodeExtractor
                 }
 
                 unset($pending[$key]);
-                $anyActivity = true;
-            }
-
-            if (! $anyActivity) {
-                $this->waitForWorkerOutput($pending);
             }
         }
 
@@ -387,23 +383,29 @@ final readonly class ParallelClassNodeExtractor
     }
 
     /**
-     * Blocks until at least one worker stdout stream becomes readable (or reaches EOF), instead of spinning.
+     * Waits (bounded) until at least one worker's stdout socket is readable or at EOF, and returns those
+     * workers' streams keyed like $pending, so the caller reads only streams that have something for it.
      *
      * @param array<int, array{stdoutPipe: resource}> $pending
+     * @return array<int, resource>
      */
-    private function waitForWorkerOutput(array $pending): void
+    private function readableWorkers(array $pending): array
     {
-        $read   = [];
+        $all = [];
+
+        foreach ($pending as $key => $worker) {
+            $all[$key] = $worker['stdoutPipe'];
+        }
+
+        $read   = $all;
         $write  = null;
         $except = null;
 
-        foreach ($pending as $worker) {
-            $read[] = $worker['stdoutPipe'];
-        }
+        // The timeout only bounds how long we wait when no worker writes anything. A false return
+        // (interrupted by a signal) degrades to polling every worker once, exactly as a timeout would.
+        $selected = @stream_select($read, $write, $except, 0, 50000);
 
-        // Wait at most 50 ms, returning earlier when data or EOF makes a stream readable.
-        // On error (including signal interruption), the caller polls every stream again on its next iteration.
-        @stream_select($read, $write, $except, 0, 50000);
+        return $selected === false ? $all : $read;
     }
 
     /**

--- a/src/Analyser/Parallel/ParallelClassNodeExtractor.php
+++ b/src/Analyser/Parallel/ParallelClassNodeExtractor.php
@@ -151,15 +151,12 @@ final readonly class ParallelClassNodeExtractor
 
                 $data = fread($stdoutPipe, 8192);
                 if ($data !== false && $data !== '') {
-                    $workerFiles = $pending[$key]['files'];
-                    $nextFileIdx = $pending[$key]['filesAdvanced'];
-                    $lastFileIdx = min($nextFileIdx + substr_count($data, "\n"), count($workerFiles));
-
-                    for (; $nextFileIdx < $lastFileIdx; $nextFileIdx++) {
-                        $progressHandler?->advance($workerFiles[$nextFileIdx]);
-                    }
-
-                    $pending[$key]['filesAdvanced'] = $nextFileIdx;
+                    $pending[$key]['filesAdvanced'] = $this->advanceProgress(
+                        $pending[$key]['files'],
+                        $pending[$key]['filesAdvanced'],
+                        $pending[$key]['filesAdvanced'] + substr_count($data, "\n"),
+                        $progressHandler
+                    );
 
                     $anyActivity = true;
                 }
@@ -168,7 +165,7 @@ final readonly class ParallelClassNodeExtractor
                     continue;
                 }
 
-                // Pipe EOF means the worker exited and the OS closed its write end.
+                // Socket EOF means the worker exited and the OS closed its write end.
                 // proc_close() has not been called yet so waitpid() inside it correctly
                 // returns the real exit code (no double-waitpid race with proc_get_status).
                 fclose($stdoutPipe);
@@ -176,6 +173,19 @@ final readonly class ParallelClassNodeExtractor
                 $procResource = $pending[$key]['process'];
                 assert(is_resource($procResource));
                 $exitCode = proc_close($procResource);
+
+                // A worker that exited cleanly has processed every file in its bucket, so any progress
+                // markers still in flight when the socket closed are redundant. Advance the remainder here
+                // rather than trusting the stream: on Windows, EOF can be observed before the last bytes
+                // the worker wrote have been read, which would otherwise silently drop those events.
+                if ($exitCode === 0) {
+                    $this->advanceProgress(
+                        $pending[$key]['files'],
+                        $pending[$key]['filesAdvanced'],
+                        count($pending[$key]['files']),
+                        $progressHandler
+                    );
+                }
 
                 try {
                     // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName
@@ -353,6 +363,27 @@ final readonly class ParallelClassNodeExtractor
         }
 
         return new ExtractionResult($nodes, $fileAnalyses, $anonymousClassNodes, $fileReferences, $fileInstantiations);
+    }
+
+    /**
+     * Emits progress for $workerFiles[$nextFileIdx .. $lastFileIdx), capped at the bucket size, and returns
+     * the index of the first file not yet reported so a file is never reported twice.
+     *
+     * @param list<string> $workerFiles
+     */
+    private function advanceProgress(
+        array $workerFiles,
+        int $nextFileIdx,
+        int $lastFileIdx,
+        ?ProgressHandlerInterface $progressHandler,
+    ): int {
+        $lastFileIdx = min($lastFileIdx, count($workerFiles));
+
+        for (; $nextFileIdx < $lastFileIdx; $nextFileIdx++) {
+            $progressHandler?->advance($workerFiles[$nextFileIdx]);
+        }
+
+        return $nextFileIdx;
     }
 
     /**

--- a/src/Analyser/Parallel/ParallelClassNodeExtractor.php
+++ b/src/Analyser/Parallel/ParallelClassNodeExtractor.php
@@ -153,7 +153,7 @@ final readonly class ParallelClassNodeExtractor
                 $stdoutPipe = $worker['stdoutPipe'];
 
                 $data = fread($stdoutPipe, 8192);
-                if ($data !== false && $data !== '') {
+                if ($emitProgress && $data !== false && $data !== '') {
                     $pending[$key]['filesAdvanced'] = $this->advanceProgress(
                         $pending[$key]['files'],
                         $pending[$key]['filesAdvanced'],
@@ -179,7 +179,7 @@ final readonly class ParallelClassNodeExtractor
                 // markers still in flight when the socket closed are redundant. Advance the remainder here
                 // rather than trusting the stream: on Windows, EOF can be observed before the last bytes
                 // the worker wrote have been read, which would otherwise silently drop those events.
-                if ($exitCode === 0) {
+                if ($exitCode === 0 && $emitProgress) {
                     $this->advanceProgress(
                         $pending[$key]['files'],
                         $pending[$key]['filesAdvanced'],
@@ -371,12 +371,12 @@ final readonly class ParallelClassNodeExtractor
         array $workerFiles,
         int $nextFileIdx,
         int $lastFileIdx,
-        ?ProgressHandlerInterface $progressHandler,
+        ProgressHandlerInterface $progressHandler,
     ): int {
         $lastFileIdx = min($lastFileIdx, count($workerFiles));
 
         for (; $nextFileIdx < $lastFileIdx; $nextFileIdx++) {
-            $progressHandler?->advance($workerFiles[$nextFileIdx]);
+            $progressHandler->advance($workerFiles[$nextFileIdx]);
         }
 
         return $nextFileIdx;

--- a/src/Analyser/Parallel/ParallelClassNodeExtractor.php
+++ b/src/Analyser/Parallel/ParallelClassNodeExtractor.php
@@ -34,11 +34,11 @@ use function mkdir;
 use function proc_close;
 use function serialize;
 use function sprintf;
+use function stream_select;
 use function stream_set_blocking;
 use function substr_count;
 use function unlink;
 use function unserialize;
-use function usleep;
 
 use const PHP_BINARY;
 
@@ -105,7 +105,9 @@ final readonly class ParallelClassNodeExtractor
                 [PHP_BINARY, $script, '--internal-worker', $inputFile, $outputFile],
                 [
                     0 => ['pipe', 'r'],
-                    1 => ['pipe', 'w'],
+                    // Use a socket pair instead of an anonymous pipe: stream_select() cannot monitor
+                    // proc_open() pipe handles on Windows, but it can monitor socket descriptors.
+                    1 => ['socket'],
                     2 => ['file', $stderrFile, 'w'],
                 ],
                 $pipes,
@@ -342,7 +344,7 @@ final readonly class ParallelClassNodeExtractor
             }
 
             if (! $anyActivity) {
-                usleep(5000);
+                $this->waitForWorkerOutput($pending);
             }
         }
 
@@ -351,6 +353,26 @@ final readonly class ParallelClassNodeExtractor
         }
 
         return new ExtractionResult($nodes, $fileAnalyses, $anonymousClassNodes, $fileReferences, $fileInstantiations);
+    }
+
+    /**
+     * Blocks until at least one worker stdout stream becomes readable (or reaches EOF), instead of spinning.
+     *
+     * @param array<int, array{stdoutPipe: resource}> $pending
+     */
+    private function waitForWorkerOutput(array $pending): void
+    {
+        $read   = [];
+        $write  = null;
+        $except = null;
+
+        foreach ($pending as $worker) {
+            $read[] = $worker['stdoutPipe'];
+        }
+
+        // Wait at most 50 ms, returning earlier when data or EOF makes a stream readable.
+        // On error (including signal interruption), the caller polls every stream again on its next iteration.
+        @stream_select($read, $write, $except, 0, 50000);
     }
 
     /**

--- a/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
+++ b/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
@@ -6,7 +6,7 @@ namespace Boundwize\StructArmed\Tests\Analyser\Parallel;
 
 use Boundwize\StructArmed\Analyser\ClassNode;
 use Boundwize\StructArmed\Analyser\Parallel\ParallelClassNodeExtractor;
-use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
+use Boundwize\StructArmed\Tests\Support\RecordingProgressHandler;
 use Boundwize\StructArmed\Tests\Support\TemporaryDirectoryCleanupTrait;
 use Iterator;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -646,29 +646,7 @@ PHP, $i));
             return $file;
         }, range(1, 120));
 
-        $progressHandler = new class implements ProgressHandlerInterface {
-            /** @var list<string> */
-            private array $advanced = [];
-
-            public function start(int $total): void
-            {
-            }
-
-            public function advance(string $file): void
-            {
-                $this->advanced[] = $file;
-            }
-
-            public function finish(): void
-            {
-            }
-
-            /** @return list<string> */
-            public function advanced(): array
-            {
-                return $this->advanced;
-            }
-        };
+        $progressHandler = new RecordingProgressHandler();
 
         $parallelClassNodeExtractor = new ParallelClassNodeExtractor(
             basePath: $dir,
@@ -725,5 +703,38 @@ PHP, $i));
         fclose($pipes[2]);
 
         $this->assertSame(0, proc_close($process));
+    }
+
+    /**
+     * Progress must be complete even if the stdout socket delivers no markers at all: a worker that exited
+     * cleanly has processed its whole bucket, so the extractor reports the remainder itself. Windows CI
+     * observed EOF before the final bytes were read, losing the tail of each worker's progress.
+     */
+    public function testProgressIsCompletedOnCleanExitWhenNoMarkersWereReceived(): void
+    {
+        // A "worker" that writes nothing to stdout and exits 0; the result payload is supplied via the mock.
+        $GLOBALS['mock_proc_open_command']         = [PHP_BINARY, '-r', 'exit(0);'];
+        $GLOBALS['mock_file_get_contents_payload'] = ['nodes' => [], 'error' => null];
+
+        $dir   = $this->makeTemporaryDirectory('structarmed-parallel-test');
+        $files = [];
+
+        foreach (['Foo', 'Bar', 'Baz'] as $name) {
+            $files[] = $file = sprintf('%s/%s.php', $dir, $name);
+            file_put_contents($file, sprintf('<?php class %s {}', $name));
+        }
+
+        $progressHandler            = new RecordingProgressHandler();
+        $parallelClassNodeExtractor = new ParallelClassNodeExtractor($dir, [], [], 1);
+
+        try {
+            $parallelClassNodeExtractor->extract($files, $progressHandler);
+        } finally {
+            $GLOBALS['mock_proc_open_command']         = null;
+            $GLOBALS['mock_file_get_contents_payload'] = null;
+            $GLOBALS['mock_tracked_tempnam_files']     = [];
+        }
+
+        $this->assertSame($files, $progressHandler->advanced());
     }
 }

--- a/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
+++ b/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
@@ -6,6 +6,7 @@ namespace Boundwize\StructArmed\Tests\Analyser\Parallel;
 
 use Boundwize\StructArmed\Analyser\ClassNode;
 use Boundwize\StructArmed\Analyser\Parallel\ParallelClassNodeExtractor;
+use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
 use Boundwize\StructArmed\Tests\Support\TemporaryDirectoryCleanupTrait;
 use Iterator;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -13,12 +14,16 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
+use function array_map;
 use function bin2hex;
 use function file_put_contents;
 use function glob;
 use function is_dir;
 use function random_bytes;
+use function range;
 use function rmdir;
+use function sort;
+use function sprintf;
 use function sys_get_temp_dir;
 use function unlink;
 
@@ -609,5 +614,72 @@ PHP);
             $GLOBALS['mock_file_get_contents_payload'] = null;
             $GLOBALS['mock_tracked_tempnam_files']     = [];
         }
+    }
+
+    /**
+     * Stress the socket + stream_select() wait loop: many files spread across several workers must yield
+     * exactly one progress event per file, with none lost or duplicated. This runs on every CI OS, which
+     * matters most on Windows where proc_open() pipes are not selectable and a socket pair is used instead.
+     */
+    public function testProgressEventsAreReceivedForEveryFileAcrossManyWorkers(): void
+    {
+        $dir   = $this->makeTemporaryDirectory('structarmed-parallel-stress');
+        $files = array_map(static function (int $i) use ($dir): string {
+            $file = sprintf('%s/Class%03d.php', $dir, $i);
+
+            file_put_contents($file, sprintf(<<<'PHP'
+<?php
+
+namespace App\Domain;
+
+final class Class%03d
+{
+}
+PHP, $i));
+
+            return $file;
+        }, range(1, 120));
+
+        $progressHandler = new class implements ProgressHandlerInterface {
+            /** @var list<string> */
+            private array $advanced = [];
+
+            public function start(int $total): void
+            {
+            }
+
+            public function advance(string $file): void
+            {
+                $this->advanced[] = $file;
+            }
+
+            public function finish(): void
+            {
+            }
+
+            /** @return list<string> */
+            public function advanced(): array
+            {
+                return $this->advanced;
+            }
+        };
+
+        $parallelClassNodeExtractor = new ParallelClassNodeExtractor(
+            basePath: $dir,
+            layers: ['Domain' => 'App\\Domain'],
+            layerPatterns: [],
+            workerCount: 6,
+        );
+
+        $extractionResult = $parallelClassNodeExtractor->extract($files, $progressHandler);
+
+        $this->assertCount(120, $extractionResult->classNodes);
+
+        $expected = $files;
+        $advanced = $progressHandler->advanced();
+        sort($expected);
+        sort($advanced);
+
+        $this->assertSame($expected, $advanced);
     }
 }

--- a/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
+++ b/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
@@ -724,7 +724,7 @@ PHP, $i));
             file_put_contents($file, sprintf('<?php class %s {}', $name));
         }
 
-        $recordingProgressHandler            = new RecordingProgressHandler();
+        $recordingProgressHandler   = new RecordingProgressHandler();
         $parallelClassNodeExtractor = new ParallelClassNodeExtractor($dir, [], [], 1);
 
         try {

--- a/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
+++ b/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
@@ -16,14 +16,20 @@ use RuntimeException;
 
 use function array_map;
 use function bin2hex;
+use function fclose;
 use function file_put_contents;
 use function glob;
 use function is_dir;
+use function is_resource;
+use function proc_close;
+use function proc_open;
 use function random_bytes;
 use function range;
 use function rmdir;
 use function sort;
 use function sprintf;
+use function stream_get_contents;
+use function stream_select;
 use function sys_get_temp_dir;
 use function unlink;
 
@@ -681,5 +687,43 @@ PHP, $i));
         sort($advanced);
 
         $this->assertSame($expected, $advanced);
+    }
+
+    /**
+     * The extractor relies on stream_select() reporting a proc_open() ['socket'] stream as readable once the
+     * child writes. If that silently failed (returned false) the wait loop would still terminate, because it
+     * polls again, but it would have degraded into a busy loop. Assert the primitive itself on every CI OS.
+     */
+    public function testStreamSelectReportsProcOpenSocketAsReadable(): void
+    {
+        $pipes   = [];
+        $process = proc_open(
+            [PHP_BINARY, '-r', 'usleep(100000); echo "ready";'],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['socket'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+        );
+
+        $this->assertTrue(is_resource($process));
+        $this->assertArrayHasKey(1, $pipes);
+
+        $read   = [$pipes[1]];
+        $write  = null;
+        $except = null;
+
+        $selected = stream_select($read, $write, $except, 5);
+
+        $this->assertSame(1, $selected);
+        $this->assertSame([$pipes[1]], $read);
+        $this->assertSame('ready', stream_get_contents($pipes[1]));
+
+        fclose($pipes[0]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $this->assertSame(0, proc_close($process));
     }
 }

--- a/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
+++ b/tests/Analyser/Parallel/ParallelClassNodeExtractorTest.php
@@ -646,7 +646,7 @@ PHP, $i));
             return $file;
         }, range(1, 120));
 
-        $progressHandler = new RecordingProgressHandler();
+        $recordingProgressHandler = new RecordingProgressHandler();
 
         $parallelClassNodeExtractor = new ParallelClassNodeExtractor(
             basePath: $dir,
@@ -655,12 +655,12 @@ PHP, $i));
             workerCount: 6,
         );
 
-        $extractionResult = $parallelClassNodeExtractor->extract($files, $progressHandler);
+        $extractionResult = $parallelClassNodeExtractor->extract($files, $recordingProgressHandler);
 
         $this->assertCount(120, $extractionResult->classNodes);
 
         $expected = $files;
-        $advanced = $progressHandler->advanced();
+        $advanced = $recordingProgressHandler->advanced();
         sort($expected);
         sort($advanced);
 
@@ -724,17 +724,17 @@ PHP, $i));
             file_put_contents($file, sprintf('<?php class %s {}', $name));
         }
 
-        $progressHandler            = new RecordingProgressHandler();
+        $recordingProgressHandler            = new RecordingProgressHandler();
         $parallelClassNodeExtractor = new ParallelClassNodeExtractor($dir, [], [], 1);
 
         try {
-            $parallelClassNodeExtractor->extract($files, $progressHandler);
+            $parallelClassNodeExtractor->extract($files, $recordingProgressHandler);
         } finally {
             $GLOBALS['mock_proc_open_command']         = null;
             $GLOBALS['mock_file_get_contents_payload'] = null;
             $GLOBALS['mock_tracked_tempnam_files']     = [];
         }
 
-        $this->assertSame($files, $progressHandler->advanced());
+        $this->assertSame($files, $recordingProgressHandler->advanced());
     }
 }

--- a/tests/Support/RecordingProgressHandler.php
+++ b/tests/Support/RecordingProgressHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boundwize\StructArmed\Tests\Support;
+
+use Boundwize\StructArmed\Progress\ProgressHandlerInterface;
+
+final class RecordingProgressHandler implements ProgressHandlerInterface
+{
+    /** @var list<string> */
+    private array $advanced = [];
+
+    public function start(int $total): void
+    {
+    }
+
+    public function advance(string $file): void
+    {
+        $this->advanced[] = $file;
+    }
+
+    public function finish(): void
+    {
+    }
+
+    /** @return list<string> */
+    public function advanced(): array
+    {
+        return $this->advanced;
+    }
+}


### PR DESCRIPTION
`stream_select()` can work on Windows with a `socket` instead of a `pipe`.