### PR TITLE
perf: Reduce parallel worker cache payload size

### DIFF
--- a/src/Analyser/Parallel/ParallelAnalysisNodeExtractor.php
+++ b/src/Analyser/Parallel/ParallelAnalysisNodeExtractor.php
@@ -104,7 +104,7 @@ final readonly class ParallelAnalysisNodeExtractor
                 'files'            => $chunk,
                 'emitProgress'     => $emitProgress,
                 'withFileAnalysis' => $withFileAnalysis,
-                'cache'            => $this->analysisResultCache,
+                'cache'            => $this->analysisResultCache?->forFiles($chunk),
                 'cacheNamespace'   => $this->analysisNodeCacheNamespace,
             ]));
 

--- a/src/Cache/AnalysisResultCache.php
+++ b/src/Cache/AnalysisResultCache.php
@@ -76,7 +76,7 @@ final class AnalysisResultCache
 
     public function __construct(
         string $basePath,
-        private readonly FileHashProvider $fileHashProvider,
+        private FileHashProvider $fileHashProvider,
         ?string $cacheDirectory = null,
         private readonly string $configHash = '',
         private readonly string $composerGeneratedVersionHash = '',
@@ -163,6 +163,17 @@ final class AnalysisResultCache
     public function getCacheDirectory(): string
     {
         return $this->cacheDirectory;
+    }
+
+    /**
+     * @param list<string> $files
+     */
+    public function forFiles(array $files): self
+    {
+        $cache                   = clone $this;
+        $cache->fileHashProvider = $this->fileHashProvider->forFiles($files);
+
+        return $cache;
     }
 
     /**

--- a/src/Cache/FileHashProvider.php
+++ b/src/Cache/FileHashProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Boundwize\StructArmed\Cache;
 
+use function array_fill_keys;
+use function array_intersect_key;
 use function hash_file;
 
 /**
@@ -28,6 +30,17 @@ final class FileHashProvider
         }
 
         return $this->hashes[$file] = $hash;
+    }
+
+    /**
+     * @param list<string> $files
+     */
+    public function forFiles(array $files): self
+    {
+        $provider         = new self();
+        $provider->hashes = array_intersect_key($this->hashes, array_fill_keys($files, true));
+
+        return $provider;
     }
 
     public function clear(): void

--- a/tests/Analyser/Parallel/ParallelAnalysisNodeExtractorTest.php
+++ b/tests/Analyser/Parallel/ParallelAnalysisNodeExtractorTest.php
@@ -6,6 +6,8 @@ namespace Boundwize\StructArmed\Tests\Analyser\Parallel;
 
 use Boundwize\StructArmed\Analyser\ClassNode;
 use Boundwize\StructArmed\Analyser\Parallel\ParallelAnalysisNodeExtractor;
+use Boundwize\StructArmed\Cache\AnalysisResultCache;
+use Boundwize\StructArmed\Cache\FileHashProvider;
 use Boundwize\StructArmed\Tests\Support\TemporaryDirectoryCleanupTrait;
 use Iterator;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -158,6 +160,45 @@ PHP);
 
         $this->assertCount(1, $extractionResult->classNodes);
         $this->assertSame('App\\Domain\\Baz', $extractionResult->classNodes[0]->className);
+    }
+
+    public function testWorkersStoreValidAnalysisNodeCacheEntriesWithScopedFileHashes(): void
+    {
+        $dir      = $this->makeTemporaryDirectory('structarmed-parallel-test');
+        $cacheDir = $this->makeTemporaryDirectory('structarmed-parallel-cache');
+        $fooFile  = $dir . '/Foo.php';
+        $barFile  = $dir . '/Bar.php';
+
+        file_put_contents($fooFile, '<?php namespace App; final class Foo {}');
+        file_put_contents($barFile, '<?php namespace App; final class Bar {}');
+
+        $fileHashProvider = new FileHashProvider();
+        $fileHashProvider->hash($fooFile);
+        $fileHashProvider->hash($barFile);
+
+        $analysisResultCache = new AnalysisResultCache($dir, $fileHashProvider, $cacheDir);
+
+        (new ParallelAnalysisNodeExtractor(
+            basePath: $dir,
+            layers: [],
+            layerPatterns: [],
+            workerCount: 2,
+            cacheDirectory: $cacheDir,
+            analysisResultCache: $analysisResultCache,
+            analysisNodeCacheNamespace: 'config',
+        ))->extract([$fooFile, $barFile]);
+
+        $freshCache = new AnalysisResultCache($dir, new FileHashProvider(), $cacheDir);
+
+        $this->assertIsArray($freshCache->loadAnalysisNodes($fooFile, 'config'));
+        $this->assertIsArray($freshCache->loadAnalysisNodes($barFile, 'config'));
+
+        file_put_contents($fooFile, '<?php namespace App; final class Foo { public function changed(): void {} }');
+
+        $changedFileCache = new AnalysisResultCache($dir, new FileHashProvider(), $cacheDir);
+
+        $this->assertNull($changedFileCache->loadAnalysisNodes($fooFile, 'config'));
+        $this->assertIsArray($changedFileCache->loadAnalysisNodes($barFile, 'config'));
     }
 
     public function testExtractWithLayerPatternsUsesChainResolver(): void

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -69,6 +69,42 @@ final class AnalysisResultCacheTest extends TestCase
         }
     }
 
+    public function testForFilesUsesOnlyRequestedMemoisedHashes(): void
+    {
+        $directory     = $this->createTempDirectory();
+        $cacheDir      = $this->createTempDirectory();
+        $retainedFile  = $directory . '/Retained.php';
+        $unrelatedFile = $directory . '/Unrelated.php';
+
+        file_put_contents($retainedFile, '<?php class Retained {}');
+        file_put_contents($unrelatedFile, '<?php class Unrelated {}');
+
+        $fileHashProvider = new FileHashProvider();
+        $fileHashProvider->hash($retainedFile);
+        $fileHashProvider->hash($unrelatedFile);
+
+        $cacheForFile = (new AnalysisResultCache($directory, $fileHashProvider, $cacheDir))
+            ->forFiles([$retainedFile]);
+
+        file_put_contents($retainedFile, '<?php final class Retained {}');
+        file_put_contents($unrelatedFile, '<?php final class Unrelated {}');
+
+        try {
+            $cacheForFile->storeAnalysisNodes($retainedFile, 'config', []);
+            $cacheForFile->storeAnalysisNodes($unrelatedFile, 'config', []);
+
+            $analysisResultCache = new AnalysisResultCache($directory, new FileHashProvider(), $cacheDir);
+
+            $this->assertNull($analysisResultCache->loadAnalysisNodes($retainedFile, 'config'));
+            $this->assertIsArray($analysisResultCache->loadAnalysisNodes($unrelatedFile, 'config'));
+        } finally {
+            unlink($retainedFile);
+            unlink($unrelatedFile);
+            $this->removeTempDirectory($directory);
+            $this->removeTempDirectory($cacheDir);
+        }
+    }
+
     public function testStoresAndLoadsViolationCollection(): void
     {
         $cacheDirectory          = $this->createTempDirectory();

--- a/tests/Cache/FileHashProviderTest.php
+++ b/tests/Cache/FileHashProviderTest.php
@@ -55,4 +55,29 @@ final class FileHashProviderTest extends TestCase
 
         $this->assertSame(hash_file('xxh128', $file), $fileHashProvider->hash($file));
     }
+
+    public function testForFilesCopiesOnlyRequestedMemoisedHashes(): void
+    {
+        $retainedFile  = $this->makeTemporaryFile('structarmed-file-hash');
+        $unrelatedFile = $this->makeTemporaryFile('structarmed-file-hash');
+        $missingFile   = $this->makeTemporaryFile('structarmed-file-hash');
+
+        file_put_contents($retainedFile, '<?php echo "retained original";');
+        file_put_contents($unrelatedFile, '<?php echo "unrelated original";');
+        file_put_contents($missingFile, '<?php echo "missing original";');
+
+        $fileHashProvider = new FileHashProvider();
+        $retainedHash     = $fileHashProvider->hash($retainedFile);
+        $fileHashProvider->hash($unrelatedFile);
+
+        $providerForFiles = $fileHashProvider->forFiles([$retainedFile, $missingFile]);
+
+        file_put_contents($retainedFile, '<?php echo "retained changed";');
+        file_put_contents($unrelatedFile, '<?php echo "unrelated changed";');
+        file_put_contents($missingFile, '<?php echo "missing changed";');
+
+        $this->assertSame($retainedHash, $providerForFiles->hash($retainedFile));
+        $this->assertSame(hash_file('xxh128', $unrelatedFile), $providerForFiles->hash($unrelatedFile));
+        $this->assertSame(hash_file('xxh128', $missingFile), $providerForFiles->hash($missingFile));
+    }
 }


### PR DESCRIPTION
Branch | Files | Cold analysis time | Difference | Improvement
-- | -- | -- | -- | --
0.17.x | 5,807 | 3.06s | — | —
payload-size | 5,807 | 2.89s | −0.17s | 5.6% faster

