### PR TITLE
perf: stream analysis cache file hashing

### DIFF
--- a/src/Cache/AnalysisCacheMetadataFactory.php
+++ b/src/Cache/AnalysisCacheMetadataFactory.php
@@ -83,13 +83,13 @@ final readonly class AnalysisCacheMetadataFactory
      */
     private function filesHash(array $files): string
     {
-        $context = hash_init('xxh128');
+        $hashContext = hash_init('xxh128');
 
         foreach ($files as $file) {
-            hash_update($context, $file . "\0" . $this->fileHashProvider->hash($file) . "\0");
+            hash_update($hashContext, $file . "\0" . $this->fileHashProvider->hash($file) . "\0");
         }
 
-        return hash_final($context);
+        return hash_final($hashContext);
     }
 
     private function composerHash(string $basePath): string

--- a/src/Cache/AnalysisCacheMetadataFactory.php
+++ b/src/Cache/AnalysisCacheMetadataFactory.php
@@ -7,9 +7,11 @@ namespace Boundwize\StructArmed\Cache;
 use Boundwize\StructArmed\Version;
 use Composer\InstalledVersions;
 
-use function array_map;
 use function file_exists;
 use function hash;
+use function hash_final;
+use function hash_init;
+use function hash_update;
 use function json_encode;
 use function rtrim;
 use function sort;
@@ -36,7 +38,7 @@ final readonly class AnalysisCacheMetadataFactory
         sort($files);
 
         return [
-            'version'                      => 4,
+            'version'                      => 5,
             'basePath'                     => $basePath,
             'configPath'                   => $configPath,
             'configHash'                   => $this->fileHash($configPath),
@@ -81,10 +83,13 @@ final readonly class AnalysisCacheMetadataFactory
      */
     private function filesHash(array $files): string
     {
-        return hash('xxh128', json_encode(array_map(fn(string $file): array => [
-            'file' => $file,
-            'hash' => $this->fileHashProvider->hash($file),
-        ], $files), JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR));
+        $context = hash_init('xxh128');
+
+        foreach ($files as $file) {
+            hash_update($context, $file . "\0" . $this->fileHashProvider->hash($file) . "\0");
+        }
+
+        return hash_final($context);
     }
 
     private function composerHash(string $basePath): string

--- a/tests/Cache/AnalysisResultCacheTest.php
+++ b/tests/Cache/AnalysisResultCacheTest.php
@@ -38,6 +38,9 @@ use function file_put_contents;
 use function glob;
 use function hash;
 use function hash_file;
+use function hash_final;
+use function hash_init;
+use function hash_update;
 use function is_dir;
 use function json_decode;
 use function json_encode;
@@ -2609,9 +2612,14 @@ final class AnalysisResultCacheTest extends TestCase
             $this->assertSame($directory, $metadata['basePath']);
             $this->assertSame($config, $metadata['configPath']);
             $this->assertSame(['src'], $metadata['scanPaths']);
+            $this->assertSame(5, $metadata['version']);
             $this->assertIsString($metadata['configHash']);
             $this->assertIsString($metadata['composerGeneratedVersionHash']);
-            $this->assertIsString($metadata['filesHash']);
+
+            $filesHashContext = hash_init('xxh128');
+            hash_update($filesHashContext, $source . "\0" . hash_file('xxh128', $source) . "\0");
+
+            $this->assertSame(hash_final($filesHashContext), $metadata['filesHash']);
             $this->assertSame(
                 (new AnalysisCacheMetadataFactory(new FileHashProvider()))->key($metadata),
                 (new AnalysisCacheMetadataFactory(new FileHashProvider()))->key($metadata)


### PR DESCRIPTION

Implementation | Files | Time | Difference | Improvement
-- | -- | -- | -- | --
Current (0.17.x) | 5,807 | 3.11s | — | —
Streaming hash | 5,807 | 2.83s | −0.28s | 9.0% faster

