### PR TITLE
Scope composer.json rules to the analysed file list on explicit path arguments

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -85,11 +85,8 @@ final readonly class Analyser
         // Composer rules follow the same scope as every other rule kind: they
         // only run when the root composer.json is part of the file list, which
         // a layer-wide scan includes and an explicit path argument may not.
-        $analysesComposerJson = in_array(
-            Path::normalise(Path::resolve('composer.json', $this->basePath), canonicalise: true),
-            $files,
-            true
-        );
+        $composerJsonFile       = Path::normalise(Path::resolve('composer.json', $this->basePath), canonicalise: true);
+        $isAnalysesComposerJson = in_array($composerJsonFile, $files, true);
 
         $projectRuleViolations      = [];
         $fileAnalysisRules          = [];
@@ -150,7 +147,7 @@ final readonly class Analyser
                 continue;
             }
 
-            if ($rule instanceof ComposerJsonRuleInterface && ! $analysesComposerJson) {
+            if ($rule instanceof ComposerJsonRuleInterface && ! $isAnalysesComposerJson) {
                 continue;
             }
 

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -80,6 +80,16 @@ final readonly class Analyser
         $globalSkipPaths = $architecture->getSkipPaths();
         $ruleSkipPaths   = $architecture->getRuleSkipPaths();
         $skippedRuleKeys = $this->skippedRuleKeyMap($architecture->getSkippedRuleKeys());
+        $files         ??= $this->filesForAnalysis($architecture, $scanPaths, $layers);
+
+        // Composer rules follow the same scope as every other rule kind: they
+        // only run when the root composer.json is part of the file list, which
+        // a layer-wide scan includes and an explicit path argument may not.
+        $analysesComposerJson = in_array(
+            Path::normalise(Path::resolve('composer.json', $this->basePath), canonicalise: true),
+            $files,
+            true
+        );
 
         $projectRuleViolations      = [];
         $fileAnalysisRules          = [];
@@ -140,6 +150,10 @@ final readonly class Analyser
                 continue;
             }
 
+            if ($rule instanceof ComposerJsonRuleInterface && ! $analysesComposerJson) {
+                continue;
+            }
+
             $projectRuleViolations[$key] = [];
 
             if ($rule instanceof FileAnalysisRuleInterface) {
@@ -168,7 +182,6 @@ final readonly class Analyser
         $layerPatterns      = $architecture->getLayerPatterns();
         $chainLayerResolver = ChainLayerResolver::fromLayerConfig($layers, $this->basePath, $layerPatterns);
 
-        $files          ??= $this->filesForAnalysis($architecture, $scanPaths, $layers);
         $withFileAnalysis = $fileAnalysisRules !== [];
         $extractionResult = $this->collectAnalysisNodes(
             $files,
@@ -1407,9 +1420,13 @@ final readonly class Analyser
         $layers        ??= $this->resolveLayers($architecture);
         $files           = [];
         $skipPathMatcher = SkipPathMatcher::compile($this->basePath, $architecture->getSkipPaths());
+        $isExplicitScan  = $scanPaths !== [];
         $scanPaths       = $this->scanPaths($layers, $scanPaths);
 
-        if ($this->shouldAnalyseComposerJson($architecture)) {
+        // The root composer.json joins a layer-wide scan automatically; an
+        // explicit path argument keeps the file list to what was named, so
+        // composer rules only run there when composer.json itself is named.
+        if (! $isExplicitScan && $this->shouldAnalyseComposerJson($architecture)) {
             $scanPaths[] = 'composer.json';
         }
 

--- a/tests/Analyser/AnalyserTest.php
+++ b/tests/Analyser/AnalyserTest.php
@@ -31,6 +31,7 @@ use Boundwize\StructArmed\Rule\FileAnalysisRuleInterface;
 use Boundwize\StructArmed\Rule\FunctionRuleInterface;
 use Boundwize\StructArmed\Rule\Rules\Class_\AnonymousClassMayNotHaveEmptyParenthesesRule;
 use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
+use Boundwize\StructArmed\Rule\Rules\Composer\Psr4DirectoryExistsRule;
 use Boundwize\StructArmed\Rule\Rules\Composer\Psr4SourcePathsRule;
 use Boundwize\StructArmed\Rule\Rules\File\Psr1PhpTagsRule;
 use Boundwize\StructArmed\Rule\Rules\File\Psr1SymbolsOrSideEffectsRule;
@@ -2684,6 +2685,45 @@ final class AnalyserTest extends TestCase
 
         $this->assertCount(1, $files);
         $this->assertStringEndsWith('/src/Foo.php', $files[0]);
+    }
+
+    public function testFilesForAnalysisDoesNotIncludeRootComposerJsonForExplicitScanPath(): void
+    {
+        $basePath = $this->makeTempProject([
+            'composer.json' => '{"autoload":{"psr-4":{"App\\\\":"src/"}}}',
+            'src/Foo.php'   => '<?php namespace App; final class Foo {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Domain', 'src/')
+            ->rule('composer.source_paths', new Psr4SourcePathsRule(['src/']));
+
+        $analyser = new Analyser($basePath);
+
+        $files = array_map($this->normalisePath(...), $analyser->filesForAnalysis($architecture, ['src/Foo.php']));
+
+        $this->assertCount(1, $files);
+        $this->assertStringEndsWith('/src/Foo.php', $files[0]);
+
+        $this->assertCount(2, $analyser->filesForAnalysis($architecture));
+    }
+
+    public function testAnalyserScopesComposerRulesToExplicitScanPaths(): void
+    {
+        $basePath = $this->makeTempProject([
+            'composer.json' => '{"autoload":{"psr-4":{"App\\\\":"src/","Missing\\\\":"missing/"}}}',
+            'src/Foo.php'   => '<?php namespace App; final class Foo {}',
+        ]);
+
+        $architecture = Architecture::define()
+            ->layer('Domain', 'src/')
+            ->rule('composer.directory_exists', new Psr4DirectoryExistsRule());
+
+        $analyser = new Analyser($basePath);
+
+        $this->assertCount(0, $analyser->analyse($architecture, ['src/Foo.php'])->forRule('composer.directory_exists'));
+        $this->assertCount(1, $analyser->analyse($architecture, ['composer.json'])->forRule('composer.directory_exists'));
+        $this->assertCount(1, $analyser->analyse($architecture)->forRule('composer.directory_exists'));
     }
 
     public function testFilesForAnalysisDoesNotIncludeRootComposerJsonWhenComposerJsonRuleIsSkipped(): void


### PR DESCRIPTION
Run on path argument without including `composer.json` now show invalid count of files

```bash
➜  structarmed git:(main) bin/structarmed analyze src/Analyser/Analyser.php --clear-cache
Analyzing [============================] 100% 2/2

StructArmed dev-main — Architecture Enforcement
=================================================

✅  No violations found. (0.17s)
```

which should be `1/1` instead of `2/2`.

This PR try to fix it.